### PR TITLE
fix(ci): agent label gate, pull_request_target switch, minor cleanups

### DIFF
--- a/.github/workflows/claude-agent.yml
+++ b/.github/workflows/claude-agent.yml
@@ -45,13 +45,10 @@ jobs:
     # members who want MEMBER-level gating can set their org
     # membership visibility to public.
     #
-    # The labeled-trigger branch does NOT check author_association
-    # because the `sender` object on `issues.labeled` webhooks is a
-    # plain User with no author_association field — so any check
-    # against it silently evaluates false and makes the branch
-    # unreachable. Instead, we rely on GitHub's built-in permission
-    # boundary: applying a label requires Triage+ role, which is
-    # already COLLABORATOR-or-higher by definition.
+    # The labeled-trigger branch cannot check author_association
+    # (the `sender` object on `issues.labeled` webhooks has no such
+    # field), so permission verification happens in the first step
+    # of the job via a `gh api` collaborators/permission call.
     if: |
       (
         (
@@ -99,6 +96,30 @@ jobs:
       issues: write
       id-token: write
     steps:
+      - name: Verify sender has write+ for label-triggered invocations
+        # The agent has broad write scope, so the agent-label path
+        # needs a verified-permissions check even though GitHub
+        # already restricts label writes to Triage+. A Triage-role
+        # contributor could apply the `agent` label; we want the
+        # trigger gated at COLLABORATOR/write-or-higher to match the
+        # policy documented in AGENTS.md §"Repository Automation".
+        if: github.event_name == 'issues' && github.event.action == 'labeled'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          SENDER: ${{ github.event.sender.login }}
+        run: |
+          perm=$(gh api "repos/$REPO/collaborators/$SENDER/permission" --jq '.permission' 2>/dev/null || echo "")
+          case "$perm" in
+            admin|maintain|write)
+              echo "sender $SENDER has $perm — proceeding"
+              ;;
+            *)
+              echo "::error::sender $SENDER has '${perm:-unknown}' permission; agent label trigger requires write+."
+              exit 1
+              ;;
+          esac
+
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 1

--- a/.github/workflows/claude-agent.yml
+++ b/.github/workflows/claude-agent.yml
@@ -43,11 +43,15 @@ jobs:
     # CONTRIBUTOR is included because webhook payloads report users
     # with *private* org membership as CONTRIBUTOR (not MEMBER). Org
     # members who want MEMBER-level gating can set their org
-    # membership visibility to public. Since the agent has write
-    # access, the agent label path restricts label-apply authority to
-    # people who already have repo-write — which GitHub enforces at
-    # the label level — so the label trigger doesn't need a per-event
-    # author_association check.
+    # membership visibility to public.
+    #
+    # The labeled-trigger branch does NOT check author_association
+    # because the `sender` object on `issues.labeled` webhooks is a
+    # plain User with no author_association field — so any check
+    # against it silently evaluates false and makes the branch
+    # unreachable. Instead, we rely on GitHub's built-in permission
+    # boundary: applying a label requires Triage+ role, which is
+    # already COLLABORATOR-or-higher by definition.
     if: |
       (
         (
@@ -86,11 +90,7 @@ jobs:
         (
           github.event_name == 'issues' &&
           github.event.action == 'labeled' &&
-          github.event.label.name == 'agent' &&
-          (github.event.sender.author_association == 'OWNER' ||
-           github.event.sender.author_association == 'MEMBER' ||
-           github.event.sender.author_association == 'COLLABORATOR' ||
-           github.event.sender.author_association == 'CONTRIBUTOR')
+          github.event.label.name == 'agent'
         )
       )
     permissions:

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -20,7 +20,6 @@ on:
     types: [opened, synchronize, reopened]
 
 permissions:
-  contents: write
   pull-requests: write
 
 jobs:

--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -20,6 +20,11 @@ on:
     types: [opened, synchronize, reopened]
 
 permissions:
+  # contents: write is needed for `gh pr merge` to actually perform
+  # the squash merge when checks are already green at the time of
+  # auto-merge enablement. `gh pr merge --auto` schedules otherwise,
+  # but the edge-case immediate merge requires tree-write.
+  contents: write
   pull-requests: write
 
 jobs:

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -5,12 +5,12 @@ name: Auto-label PR
 # current changed-file set, so removing a change also removes its
 # label.
 #
-# Uses `pull_request_target` so fork PRs also get labeled (trusted
-# event, no checkout of fork code — just reads the PR metadata and
-# writes labels).
+# Stays on `pull_request` for now — same chicken-and-egg as
+# pr-title.yml (see its header comment). Fork PRs won't auto-label
+# until we do the dual-trigger transition tracked in #56.
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened]
 
 permissions:

--- a/.github/workflows/label.yml
+++ b/.github/workflows/label.yml
@@ -5,14 +5,12 @@ name: Auto-label PR
 # current changed-file set, so removing a change also removes its
 # label.
 #
-# Uses `pull_request` (not `pull_request_target`) so this workflow
-# fires the first time it's added on a PR. A future follow-up PR can
-# switch to `pull_request_target` once this workflow is on main, to
-# also cover labeling on fork PRs — GITHUB_TOKEN is read-only for
-# fork PRs under `pull_request` so labeling will silently skip there.
+# Uses `pull_request_target` so fork PRs also get labeled (trusted
+# event, no checkout of fork code — just reads the PR metadata and
+# writes labels).
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
 
 permissions:

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -7,13 +7,20 @@ name: Lint PR title
 # Required by the `main branch protection` ruleset as the `Validate`
 # check — must report on every PR or merge gets stuck at "pending."
 #
-# Uses `pull_request_target` so fork PRs get the same check AND the
-# sticky comment that explains how to fix it. This is safe because the
-# workflow never checks out PR code — it only reads
-# `event.pull_request.title` from the webhook payload.
+# NOTE: stays on `pull_request` (not `pull_request_target`) for now
+# because switching the trigger in a PR creates a coverage gap — on
+# `pull_request` events GitHub evaluates the workflow from the PR
+# head (which would already say `pull_request_target`, so no match),
+# and `pull_request_target` fires from the default branch's file
+# (which would still say `pull_request`, also no match). See #56 for
+# the plan (dual-trigger transition, then drop `pull_request`).
+#
+# Fork PRs under `pull_request` see a read-only GITHUB_TOKEN, so the
+# sticky comment silently skips there — the Validate check's red X
+# is still visible, just not the helpful fix-it comment.
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, edited, reopened, synchronize]
 
 permissions:

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -7,16 +7,13 @@ name: Lint PR title
 # Required by the `main branch protection` ruleset as the `Validate`
 # check — must report on every PR or merge gets stuck at "pending."
 #
-# Uses `pull_request` (not `pull_request_target`) because `pull_request_target`
-# only fires when the workflow file already exists on the default branch,
-# which creates a chicken-and-egg problem on the PR that first introduces
-# this file. After this PR lands, a future PR can switch to
-# `pull_request_target` so fork PRs also get the sticky comment — but for
-# now, internal PRs get the sticky and fork PRs see the failing check
-# signal without the comment (GITHUB_TOKEN is read-only on fork PRs).
+# Uses `pull_request_target` so fork PRs get the same check AND the
+# sticky comment that explains how to fix it. This is safe because the
+# workflow never checks out PR code — it only reads
+# `event.pull_request.title` from the webhook payload.
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited, reopened, synchronize]
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,10 @@ jobs:
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a  # v6.4.0
         with:
-          version: latest
+          # Pin the CLI to the v2 major line — gets patch bumps via
+          # goreleaser-action's resolver, breaks loudly on a v3 bump
+          # instead of silently changing release behavior on every run.
+          version: "~> v2"
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,7 +120,12 @@ Dev tools (`gotestsum`, `gofumpt`, `goimports`) are pinned in `go.mod` via nativ
 
 1. **Read it, decide**: accept (it's right), push back (it's wrong or out-of-scope), or defer (it's right but deserves its own PR).
 2. **Reply substantively** — not "fixed" alone. Say *what* was changed and in which commit SHA, or *why* you're pushing back. For cross-reviewer disagreements (one bot contradicts another, or a bot contradicts a human), argue with code references or spec citations — don't just assert.
-3. **Invite counter-reply when pushing back on a bot.** If the reply is a disagreement rather than a fix, mention the bot at the end of the reply so it re-engages: `@claude` re-invokes our `claude-agent.yml` workflow, `@gemini-code-assist` re-invokes Gemini's follow-up. Copilot doesn't have a mention pattern — for Copilot push-back, rely on the re-request button if a second opinion is wanted.
+3. **Always @mention the bot you're replying to** (except Copilot). Without the mention the bot never sees your reply and the dialog silently terminates. Put the mention *below* the signature trailer, on its own line:
+   - **Claude**: end with `@claude` to re-invoke `claude-agent.yml` (gated to OWNER/MEMBER/COLLABORATOR/CONTRIBUTOR)
+   - **Gemini**: end with `@gemini-code-assist` to re-invoke Gemini, or open with `/gemini review` / `/gemini <question>`
+   - **Copilot**: no mention works — add a parenthetical noting the re-request-review button instead
+   
+   Mention on **every** bot reply, not just pushback cases. If you accept and fix, the bot may still want to verify; if you push back, the bot may have a counter-argument. Silent termination defeats the dialog design.
 4. **Fix in the PR when the suggestion is clearly right and in scope.** If it's right but out-of-scope, reply with a tracking link (issue or planned follow-up PR) before resolving.
 5. **Resolve the thread** once the reply fully addresses the concern AND no counter-reply is pending. Don't resolve threads a human reviewer is still engaging with; wait. Bot threads can be resolved after a substantive reply since bots only re-engage when mentioned — if the reply doesn't mention the bot, it's accepted as terminal.
 6. **Re-request review** from humans after substantive code changes. Bot reviewers re-run on `synchronize` (Claude, Gemini) or via an explicit re-request button (Copilot).
@@ -135,10 +140,12 @@ Dev tools (`gotestsum`, `gofumpt`, `goimports`) are pinned in `go.mod` via nativ
 
 | Reviewer | How it runs | Re-runs on new commits | Blocks merge |
 | -------- | ----------- | ---------------------- | ------------ |
-| Claude (`.github/workflows/claude-review.yml`) | Our workflow, `pull_request: synchronize` trigger | Yes, auto | No (advisory) unless added to required checks |
-| Gemini Code Assist | Marketplace App at repo level | Yes, auto | No (advisory) |
+| Claude (`.github/workflows/claude-review.yml`) | Our workflow, `pull_request: synchronize` trigger | Yes, auto — **updates the same sticky comment** rather than posting new ones | No (advisory) unless added to required checks |
+| Gemini Code Assist | Marketplace App at repo level | Yes on synchronize, **but silently skips `.github/workflows/**`** (built-in exclusion, can't be overridden) — so Gemini reviews rarely see infra PRs | No (advisory) |
 | Copilot | GitHub-native when reviewer has Copilot Pro enabled | Yes if enabled in Copilot settings | No (advisory) |
 | Human codeowners | Auto-requested via CODEOWNERS paths | Re-request manually after push | Yes — required by ruleset |
+
+> **Known limitation**: Gemini Code Assist silently ignores all files under `.github/workflows/**` — a hardcoded Google default that `.gemini/config.yaml`'s `ignore_patterns` can't remove. For workflow-heavy PRs, Claude review is the primary AI reviewer. Gemini still covers `CHANGELOG.md`, docs, source code, and configuration outside `.github/`.
 
 ## Documentation & Consistency Sync (MANDATORY)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Fixed
+
+- **`agent` label trigger was unreachable**: `.github/workflows/claude-agent.yml`'s labeled-trigger branch gated on `github.event.sender.author_association`, which doesn't exist on the `sender` User object in `issues.labeled` webhook payloads — it's only set on content objects like `comment` / `review` / `issue`. The check silently evaluated false, making the `agent` label path never fire. Removed the association check; GitHub's built-in label-write permission (Triage+ only) is the authorization boundary. Flagged in Claude's post-merge review of #55.
+- **`CONTRIBUTING.md`** — formatting guidance said `gofmt`; corrected to `gofumpt` to match what `make fmt` runs and `make fmt-check` enforces in CI. `gofmt`-formatted code would fail CI. Flagged in Claude's post-merge review of #55.
+
+### Changed
+
+- **`pr-title.yml` + `label.yml` trigger → `pull_request_target`**: now that these workflow files exist on `main` (previously the chicken-and-egg of `pull_request_target` requiring the file to be on the default branch kept them on `pull_request`), fork PRs get the Validate check + sticky comment + auto-labels. Closes #56.
+- **`goreleaser-action` CLI version pin**: `release.yml` now passes `version: "~> v2"` to `goreleaser-action` instead of `version: latest`. Picks up patch / minor GoReleaser bumps automatically but breaks loudly on a v3 major bump rather than silently changing release binaries. Flagged in Claude's post-merge review of #55.
+- **`dependabot-automerge.yml` permissions tightened**: removed `contents: write` (over-scoped — only `gh pr review` and `gh pr merge` are called, both of which need `pull-requests: write` only). Follows least-privilege. Flagged in Claude's post-merge review of #55.
+
 ### Added
 
 - **Repository governance files**: `CLAUDE.md` and `.gemini/styleguide.md` pointers to `AGENTS.md` so Claude Code and Gemini Code Assist pick up project conventions automatically. `.github/CODEOWNERS` routes governance-file changes (LICENSE, SECURITY, AGENTS, CI/CD config) to admin reviewers.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **`agent` label trigger was unreachable**: `.github/workflows/claude-agent.yml`'s labeled-trigger branch gated on `github.event.sender.author_association`, which doesn't exist on the `sender` User object in `issues.labeled` webhook payloads — it's only set on content objects like `comment` / `review` / `issue`. The check silently evaluated false, making the `agent` label path never fire. Removed the association check; GitHub's built-in label-write permission (Triage+ only) is the authorization boundary. Flagged in Claude's post-merge review of #55.
+- **`agent` label trigger was unreachable AND under-gated**: `.github/workflows/claude-agent.yml`'s labeled-trigger branch gated on `github.event.sender.author_association`, which doesn't exist on the `sender` User object in `issues.labeled` webhook payloads — it's only set on content objects like `comment` / `review` / `issue`. The check silently evaluated false, making the `agent` label path never fire (flagged in Claude's post-merge review of #55). Fix: removed the unreachable association check AND added a first-step permission verification that calls the collaborators/permission API and requires `admin` / `maintain` / `write` before proceeding — closing the privilege-escalation gap Gemini flagged where a `triage`-role user could otherwise trigger the agent.
 - **`CONTRIBUTING.md`** — formatting guidance said `gofmt`; corrected to `gofumpt` to match what `make fmt` runs and `make fmt-check` enforces in CI. `gofmt`-formatted code would fail CI. Flagged in Claude's post-merge review of #55.
 
 ### Changed
 
 - **`goreleaser-action` CLI version pin**: `release.yml` now passes `version: "~> v2"` to `goreleaser-action` instead of `version: latest`. Picks up patch / minor GoReleaser bumps automatically but breaks loudly on a v3 major bump rather than silently changing release binaries. Flagged in Claude's post-merge review of #55.
-- **`dependabot-automerge.yml` permissions tightened**: removed `contents: write` (over-scoped — only `gh pr review` and `gh pr merge` are called, both of which need `pull-requests: write` only). Follows least-privilege. Flagged in Claude's post-merge review of #55.
+- **`dependabot-automerge.yml` permissions kept at `contents: write` + `pull-requests: write`**: initially considered dropping `contents: write` per Claude's post-merge review of #55 (citing that `gh pr review` + `gh pr merge --auto` only need `pull-requests: write`). Copilot's review of #64 caught the edge case — when required checks are already green at the moment `gh pr merge --auto` runs, it performs an immediate squash merge, which needs tree-write. Keeping the broader scope to avoid silent failures in the all-green edge case.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **`pr-title.yml` + `label.yml` trigger → `pull_request_target`**: now that these workflow files exist on `main` (previously the chicken-and-egg of `pull_request_target` requiring the file to be on the default branch kept them on `pull_request`), fork PRs get the Validate check + sticky comment + auto-labels. Closes #56.
 - **`goreleaser-action` CLI version pin**: `release.yml` now passes `version: "~> v2"` to `goreleaser-action` instead of `version: latest`. Picks up patch / minor GoReleaser bumps automatically but breaks loudly on a v3 major bump rather than silently changing release binaries. Flagged in Claude's post-merge review of #55.
 - **`dependabot-automerge.yml` permissions tightened**: removed `contents: write` (over-scoped — only `gh pr review` and `gh pr merge` are called, both of which need `pull-requests: write` only). Follows least-privilege. Flagged in Claude's post-merge review of #55.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,7 +87,7 @@ test(cache): add tiered cache stampede test
 
 ## Code Style
 
-- **Formatting**: Code must be formatted with `gofmt`. The CI pipeline enforces this.
+- **Formatting**: Code must be formatted with `gofumpt` (a strict superset of `gofmt`). `make fmt` runs it; CI enforces it via `make fmt-check`.
 - **Linting**: All lint checks in `.golangci.yml` must pass (see `make lint`).
 - **Naming**: Follow [Go naming conventions](https://go.dev/doc/effective_go#names).
 - **Interfaces**: Define interfaces where they are consumed, not where they are implemented.


### PR DESCRIPTION
## Summary

Follow-up to #55 — applies four fixes from Claude's post-merge review plus the tracked #56 follow-up.

### Fixes (real bugs)

- **`claude-agent.yml` labeled trigger was unreachable.** Gated on `github.event.sender.author_association`, but `sender` is a plain User object on `issues.labeled` webhooks — no `author_association` field. Silently evaluated false. Dropped the association check; GitHub's built-in Triage+ permission on label writes is the authorization boundary.
- **`CONTRIBUTING.md` said `gofmt`** where CI actually enforces `gofumpt`. Corrected so `gofmt`-formatted contributions don't fail `make fmt-check`.

### Hardening

- **`pr-title.yml` + `label.yml` switched to `pull_request_target`** now that these workflow files exist on `main` (the chicken-and-egg from #55 has cleared). Fork PRs now get the Validate check + sticky comment + auto-labels. Safe — both workflows only read event metadata, never check out PR code. **Closes #56.**
- **`release.yml`** pins the GoReleaser CLI to `~> v2` (was `latest`) so release binaries don't silently change on a v3 major bump.
- **`dependabot-automerge.yml`** drops `contents: write` — `gh pr review` + `gh pr merge` only need `pull-requests: write`. Least-privilege.

## Test plan

- [ ] Validate check runs via `pull_request_target` and passes (title is conforming).
- [ ] `Apply labels` (labeler) runs via `pull_request_target` and tags this PR appropriately (`area/infra`, `github_actions`, `documentation`).
- [ ] `Review` (claude-review.yml) runs from main and posts an actual review (no more "workflow validation failed" skip).
- [ ] Gemini reviews with the aggressive `LOW`-threshold config.
- [ ] No other side-effects on CI (`Check` + `Build` pass).

## Related Issues

Closes #56