### PR TITLE
fix(ci): unblock claude-review and coverage badge on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,13 @@ jobs:
       # harmless (config + profile already satisfy it).
       - name: Publish coverage badge
         if: github.ref == 'refs/heads/main'
-        uses: vladopajic/go-test-coverage@8cfd056d3bc5cc2bc64a840ded0c907aaae3dc46 # v2.18.7
+        # v2.18.8 fixes a regression in v2.18.5–v2.18.7 where
+        # findFilePathMatchingSearch returned -1 on an exact filename
+        # match (PR #312 / issue from #308). v2.18.7 surfaced as
+        # "could not find file [github.com/.../internal/api/dlq.go]"
+        # on the first profile entry whose stripped name matched a
+        # walked file at pos 0.
+        uses: vladopajic/go-test-coverage@a93b868a4cbcbf18dc3781650fad241f0020e609 # v2.18.8
         with:
           config: ./.testcoverage.yml
           git-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -142,10 +142,12 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Read the PR's current state in one round-trip: draft,
-          # author, association, head SHA, and the full check rollup.
+          # Read draft / author / head SHA / check rollup via gh pr view.
+          # author_association is *not* a valid `gh pr view --json` field
+          # (it's REST-only), so fetch it separately from the REST PR
+          # endpoint after the early-exit gates pass.
           pr=$(gh pr view "$PR_NUM" -R "$REPO" \
-            --json isDraft,author,authorAssociation,headRefOid,statusCheckRollup)
+            --json isDraft,author,headRefOid,statusCheckRollup)
 
           if [ "$(echo "$pr" | jq -r '.isDraft')" = "true" ]; then
             echo "::notice::PR #$PR_NUM is draft; skipping review."
@@ -158,7 +160,7 @@ jobs:
             echo "skip=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
-          association=$(echo "$pr" | jq -r '.authorAssociation')
+          association=$(gh api "repos/$REPO/pulls/$PR_NUM" --jq '.author_association')
           # CONTRIBUTOR is included because webhook payloads report users
           # with *private* org membership as CONTRIBUTOR (not MEMBER) even
           # when the REST API reports them as MEMBER.


### PR DESCRIPTION
## Summary

Two independent CI failures surfaced after #89 merged. Both are fixed here. A third issue (project-orchestrator) was diagnosed in the same investigation but is PAT-scope only — handled out-of-band by adding *Pull requests: Read* to `PROJECT_BOARD_TOKEN`.

### 1. `claude-review.yml` — `Unknown JSON field: \"authorAssociation\"`

The author-trust gate did `gh pr view --json ...,authorAssociation,...`. `authorAssociation` is **not** a valid `gh pr view --json` field — it's REST-only — and the runner's `gh` errors out before the gate can evaluate. Every workflow_run-triggered review since main CI turned green has failed at this step.

**Fix:** drop `authorAssociation` from the `gh pr view` call, fetch it via `gh api repos/$REPO/pulls/$PR_NUM --jq '.author_association'` after the draft/Dependabot early-exits. (Saves a round-trip when those gates skip the review.)

### 2. `ci.yml` — `could not find file [github.com/.../internal/api/dlq.go]`

`vladopajic/go-test-coverage` v2.18.5–v2.18.7 has a regression in `findFilePathMatchingSearch`:

```go
if pos == 0 { // 100% match
    return bestIndex   // <-- still -1; should be `i`
}
```

When a profile entry's stripped name matches a walked file at position 0, the sentinel `-1` is returned and the caller reports the file as missing. The badge step is gated `if: github.ref == 'refs/heads/main'`, so the bug never showed up in #89's PR CI — only fired on the post-merge main run. Fixed upstream in [PR #312](https://github.com/vladopajic/go-test-coverage/pull/312) (v2.18.8).

**Fix:** bump `vladopajic/go-test-coverage` v2.18.7 → v2.18.8 (SHA-pinned).

### 3. Project orchestrator — `Resource not accessible by personal access token` (out-of-PR)

Diagnosed but not changed in this PR. `board-fetch-item.sh` runs `gh api graphql resource(url:)` on a PR URL with `PROJECT_BOARD_TOKEN`. That GraphQL field requires PR-read scope on the token, which the existing PAT lacked. The composite-action docstring at `.github/actions/board-upsert-status/action.yml:12` already calls this requirement out (\"project:write AND repo:read scopes\"). The PAT scope has been updated; no workflow change needed.

Why it surfaced now: this step is gated on `bot-clean == true` (CI green + threads resolved). The recent successful orchestrator runs were `pull_request_target` events where bot-clean was false and the step skipped. The first workflow_run + bot-clean=true combination tripped it.

## Local impact

None. `make ci` doesn't use the badge action — it runs `scripts/cov` directly for thresholds and breakdown. The action only runs in the `Publish coverage badge` step on main pushes, where it now reads the already-produced `tmp/coverage/unit/coverage.txt`, computes percentages, and pushes the SVG to the `badges` branch.

`local-prefix` in `.testcoverage.yml` is silently ignored by go-test-coverage as of v2.18.5 but still load-bearing for `scripts/cov/main.go` (prefix stripping in the breakdown), so it stays.

## Test plan

- [ ] Post-merge main CI: \"Publish coverage badge\" step succeeds
- [ ] Next internal PR's workflow_run triggers Claude review without the gh-CLI field error
- [ ] Next workflow_run + bot-clean PR exercises the orchestrator pr-status step without PAT scope error (validates the out-of-band PAT update)

🤖 Generated with [Claude Code](https://claude.com/claude-code)