### PR TITLE
fix(ci): use REST check-runs for claude-review required-check gate

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -142,12 +142,20 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Read draft / author / head SHA / check rollup via gh pr view.
-          # author_association is *not* a valid `gh pr view --json` field
-          # (it's REST-only), so fetch it separately from the REST PR
-          # endpoint after the early-exit gates pass.
+          # Read draft / author / head SHA via gh pr view.
+          # - author_association is *not* a valid `gh pr view --json`
+          #   field (REST-only), fetched separately below.
+          # - statusCheckRollup is *not* fetched here: requesting it
+          #   makes GraphQL traverse `checkSuite.workflowRun` on every
+          #   check context, which the workflow's GITHUB_TOKEN can't
+          #   read for checks owned by other integrations (Gemini,
+          #   Copilot, third-party statuses). On a PR with enough
+          #   cross-integration checks the whole call fails with
+          #   "Resource not accessible by integration" even though
+          #   the data we care about is reachable. Required-check
+          #   state is fetched via REST check-runs below instead.
           pr=$(gh pr view "$PR_NUM" -R "$REPO" \
-            --json isDraft,author,headRefOid,statusCheckRollup)
+            --json isDraft,author,headRefOid)
 
           if [ "$(echo "$pr" | jq -r '.isDraft')" = "true" ]; then
             echo "::notice::PR #$PR_NUM is draft; skipping review."
@@ -180,12 +188,23 @@ jobs:
           # On manual triggers (issue_comment, workflow_dispatch) we
           # honour the explicit ask even if CI is still red or running;
           # the human has already decided they want a review.
+          #
+          # Uses the REST check-runs endpoint (filter=latest is the
+          # default, so we get one row per check name on the head
+          # commit). Status / conclusion enum values are *lowercase*
+          # in REST where GraphQL emits uppercase. Status checks
+          # (non-check_run contexts) aren't returned by this endpoint,
+          # which is fine — our required checks (CI, PR housekeeping)
+          # are both check_runs. per_page=100 is defensive against
+          # PRs that ever exceed the default page of 30 latest checks.
           if [ "$EVENT_NAME" = "workflow_run" ]; then
-            rollup=$(echo "$pr" | jq -c '.statusCheckRollup')
+            check_runs=$(gh api \
+              "repos/$REPO/commits/$head_sha/check-runs?per_page=100" \
+              --jq '.check_runs')
             mapfile -t CHECKS < <(printf '%s\n' "$REQUIRED_CHECKS" | awk 'NF')
 
             for check in "${CHECKS[@]}"; do
-              entry=$(echo "$rollup" | jq -c --arg n "$check" '.[] | select(.name == $n)' | head -n1)
+              entry=$(echo "$check_runs" | jq -c --arg n "$check" '.[] | select(.name == $n)' | head -n1)
               if [ -z "$entry" ]; then
                 echo "::notice::Required check '$check' not yet present on PR #$PR_NUM; will retry on next workflow_run."
                 echo "skip=true" >> "$GITHUB_OUTPUT"
@@ -193,14 +212,14 @@ jobs:
               fi
               status=$(echo "$entry" | jq -r '.status // empty')
               conclusion=$(echo "$entry" | jq -r '.conclusion // empty')
-              if [ "$status" != "COMPLETED" ]; then
-                echo "::notice::Required check '$check' is $status (not COMPLETED); will retry on next workflow_run."
+              if [ "$status" != "completed" ]; then
+                echo "::notice::Required check '$check' is $status (not completed); will retry on next workflow_run."
                 echo "skip=true" >> "$GITHUB_OUTPUT"
                 exit 0
               fi
               case "$conclusion" in
-                SUCCESS|NEUTRAL|SKIPPED) ;;
-                FAILURE|CANCELLED|TIMED_OUT|STARTUP_FAILURE|ACTION_REQUIRED|STALE)
+                success|neutral|skipped) ;;
+                failure|cancelled|timed_out|startup_failure|action_required|stale)
                   echo "::notice::Required check '$check' concluded $conclusion; skipping Claude review (no point reviewing red CI)."
                   echo "skip=true" >> "$GITHUB_OUTPUT"
                   exit 0


### PR DESCRIPTION
## Summary

Second-order fix on top of #105. The author-trust + required-check gate in `claude-review.yml` now uses the REST `check-runs` endpoint instead of GraphQL's `statusCheckRollup` field on the PR view.

## Why

`gh pr view --json statusCheckRollup` asks GraphQL to navigate `checkSuite.workflowRun` on every check context on the PR's head commit. The workflow's `GITHUB_TOKEN` is not allowed to read that sub-field for checks owned by other integrations (Gemini Code Assist, Copilot, third-party statuses). When a PR has enough cross-integration checks the whole call fails with:

```
GraphQL: Resource not accessible by integration
  (...statusCheckRollup.contexts.nodes.5)
  (...nodes.0..4.checkSuite.workflowRun)
```

We don't actually use any of that traversal — the gate just needs `name`, `status`, `conclusion` for two named checks (`CI`, `PR housekeeping`). The REST endpoint returns exactly that and nothing else, so it doesn't trip the cross-integration permission issue.

This failure was always there — #105 fixing `authorAssociation` just let the script reach the next bug. Visible on PR #88 (long-lived, many integrations) but not PR #7 (fewer integrations), which is why we didn't catch it in initial testing.

## What changed

- `gh pr view --json` drops `statusCheckRollup`; keeps `isDraft`, `author`, `headRefOid`.
- New `gh api repos/$REPO/commits/$head_sha/check-runs?per_page=100` call for the rollup, only inside the `workflow_run` branch (other event paths bypass the snapshot like before).
- Status / conclusion comparisons updated from uppercase (GraphQL enum: `COMPLETED`, `SUCCESS`, ...) to lowercase (REST enum: `completed`, `success`, ...).
- Gate behavior is otherwise identical: same set of pass-through conclusions, same skip notices, same fall-through to the Claude action when CI is green.

## Verified

`gh api repos/Wave-RF/WaveHouse/commits/a4f5a6b1cc83ffdca5429c0d72fb593f3f232eda/check-runs` (PR #88's current head) returns both `CI` and `PR housekeeping` with `status=completed, conclusion=success`. No GraphQL errors.

## Out of scope (mentioned in investigation, not changed here)

- `observability` branch and `context_aware_mq_2` branch still carry pre-#89 workflow files (`board-state-sync.yml`, `claude-agent.yml`) and a pre-#77 runner label. Rebase those branches onto current `main` to drop them.
- The \"Claude\" run on `context_aware_mq_2` (event `dynamic`, runs on `ubuntu-24.04`) is GitHub Copilot Coding Agent in Claude mode, not our workflow file.
- PR #107 (observability) `PR housekeeping` failures are legitimate — the PR title exceeds 72 chars.

## Test plan

- [ ] Next workflow_run for PR #88 (or any internal PR with cross-integration checks) — the gate completes without GraphQL errors.
- [ ] Draft / Dependabot / untrusted-author PRs still skip with their respective notices.
- [ ] A green CI on a trusted-author PR still falls through to the Claude review step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)