### PR TITLE
fix(ci): claude-review on pull_request_target + orchestrator waits

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,32 +1,51 @@
 name: Claude PR review
 
-# The single Claude workflow on this repo. Auto-reviews trusted-author
-# PRs after CI completes, and accepts manual re-review requests via
-# `@claude` / `/review` comments and the workflow_dispatch button.
-# (Was previously split with `claude-agent.yml`; the agent's
-# code-modifying capability was dropped in favour of a single
-# review-only workflow with a smaller blast radius.)
+# Auto-reviews PRs whose HEAD commit was authored or pushed by someone
+# with repo permission. Accepts manual re-review via `@claude` /
+# `/review` comments and the workflow_dispatch button.
 #
 # Triggers:
-#   workflow_run     — fires after every successful CI run on a PR.
-#                      Reviews update the same sticky comment on every
-#                      run so iteration history stays in one place.
-#   issue_comment    — manual re-trigger when a trusted reviewer types
-#                      `@claude` or `/review` in a PR comment.
-#   workflow_dispatch — UI / `gh workflow run` escape hatch with an
-#                      explicit PR-number input.
+#   pull_request_target — fires on every PR open/sync/reopen/
+#                         ready-for-review immediately, not after CI.
+#                         The job's check appears in the PR's Checks
+#                         panel natively — no manual status posting.
+#                         `pull_request_target` (not `pull_request`)
+#                         because the Anthropic action needs the
+#                         CLAUDE_CODE_OAUTH_TOKEN secret and write
+#                         scope, which `pull_request` denies on fork
+#                         PRs. The trust gate below is what makes
+#                         that safe.
+#   issue_comment       — manual re-trigger when a trusted reviewer
+#                         types `@claude` or `/review` in a PR
+#                         comment.
+#   workflow_dispatch   — UI / `gh workflow run` escape hatch with
+#                         an explicit PR-number input.
 #
-# Trust gating: only OWNER / MEMBER / COLLABORATOR / CONTRIBUTOR
-# can trigger Claude (covers Eric, Taite, John, Leo + any future
-# org members; excludes drive-by fork PRs and Dependabot). The gate
-# is enforced inside the job so all three trigger paths share one
-# code path.
+# Trust gate: the HEAD commit's GitHub author OR committer must have
+# at least *read* permission on the repo. "Author" is who wrote the
+# code; "committer" is who applied/pushed it. Accepting either covers:
+#   - normal push (author == committer == trusted user)
+#   - GitHub Web UI commits (author = user, committer = web-flow)
+#   - admin pushing a fixup onto a fork PR (author = external,
+#     committer = admin) — this is the case where the previous
+#     author-only gate skipped Claude even after a trusted user
+#     pushed code.
+# Fails on:
+#   - fork PR where neither author nor committer is a collaborator
+#     (drive-by contributor)
+#   - bot accounts other than Dependabot (filtered at workflow level)
+# When the gate decides to skip, the job still completes with
+# conclusion=success (the gate step exits 0). That keeps the
+# "Claude review" check present on the PR and lets the orchestrator's
+# bot-clean wait succeed.
 #
 # Prompt structure follows Anthropic's canonical pr-review-comprehensive
 # template — see `.github/prompts/pr-review.md`. The header block we
 # prepend ("REPO: ... PR NUMBER: ...") tells Claude which PR to read
 # the full context of (diff, prior comments, prior reviews, linked
-# issues).
+# issues). The action fetches diff/comments via GitHub API; the PR
+# HEAD checkout is what lets it run local git commands against the
+# changed files.
 #
 # Gemini Code Assist (installed as a GitHub App) also reviews PRs. The
 # two reviewers operate independently and their outputs are both
@@ -34,9 +53,8 @@ name: Claude PR review
 # review-thread resolution) is the actual merge gate.
 
 on:
-  workflow_run:
-    workflows: [CI]
-    types: [completed]
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
   issue_comment:
     types: [created]
   workflow_dispatch:
@@ -46,38 +64,35 @@ on:
         required: true
         type: string
 
-# Dedup per PR — the upstream CI's workflow_run + a manual `/review`
-# comment in quick succession could otherwise schedule overlapping
-# reviews. PR-number reachable from each event payload before any
-# step runs.
+# Dedup per PR. PR number reachable from each event payload before
+# any step runs. `cancel-in-progress: true` means a fast-follow push
+# replaces an in-flight review with one against the new HEAD.
 concurrency:
-  group: claude-review-${{ github.event.workflow_run.pull_requests[0].number || github.event.issue.number || inputs.pr_number || github.run_id }}
+  group: claude-review-${{ github.event.pull_request.number || github.event.issue.number || inputs.pr_number || github.run_id }}
   cancel-in-progress: true
 
 jobs:
   review:
-    name: Review
-    # Workflow-level gate: short-circuit untrusted / non-PR / red-CI
-    # invocations before spinning up a runner pod. The job-level
-    # `if:` covers each trigger path independently:
-    #
-    #   workflow_run → only when triggered by a successful CI on a
-    #                  pull_request event (skip CI for push:main and
-    #                  failed CI runs)
-    #   issue_comment → only on PR comments (issue.pull_request != null)
-    #                   that mention @claude or /review, from a trusted
-    #                   actor
-    #   workflow_dispatch → always (manual escape hatch)
+    # The check name on the PR is the *job* name. "Claude review" is
+    # what shows up in the Checks panel and what the orchestrator's
+    # bot-clean step looks for. Keep this string and orchestrator's
+    # required-checks list in sync.
+    name: Claude review
+    # Workflow-level cheap filter: skip Dependabot (handled by
+    # dependabot-automerge.yml) and clearly-untrusted issue_comment
+    # invocations. The HEAD-committer permission check is in-script
+    # so we catch "admin pushed onto an external author's PR" —
+    # webhook author_association would still report the original
+    # opener and miss this.
     if: |
       (
-        github.event_name == 'workflow_run'
-          && github.event.workflow_run.event == 'pull_request'
-          && github.event.workflow_run.conclusion == 'success'
+        github.event_name == 'pull_request_target'
+        && github.event.pull_request.user.login != 'dependabot[bot]'
       ) || (
         github.event_name == 'issue_comment'
-          && github.event.issue.pull_request != null
-          && (contains(github.event.comment.body, '@claude') || contains(github.event.comment.body, '/review'))
-          && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR","CONTRIBUTOR"]'), github.event.comment.author_association)
+        && github.event.issue.pull_request != null
+        && (contains(github.event.comment.body, '@claude') || contains(github.event.comment.body, '/review'))
+        && contains(fromJSON('["OWNER","MEMBER","COLLABORATOR","CONTRIBUTOR"]'), github.event.comment.author_association)
       ) || (
         github.event_name == 'workflow_dispatch'
       )
@@ -87,162 +102,87 @@ jobs:
       contents: read
       pull-requests: write
       issues: write
-      checks: read
       id-token: write
     steps:
-      - name: Resolve PR number
-        id: pr
+      - name: Resolve PR + verify HEAD committer is trusted
+        id: gate
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
           EVENT_NAME: ${{ github.event_name }}
-          WORKFLOW_RUN_PR: ${{ github.event.workflow_run.pull_requests[0].number }}
+          PR_EVENT_NUM: ${{ github.event.pull_request.number }}
+          PR_EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           ISSUE_COMMENT_PR: ${{ github.event.issue.number }}
           DISPATCH_PR: ${{ inputs.pr_number }}
         run: |
           set -euo pipefail
+
+          # Resolve PR number + HEAD SHA. pull_request_target gives us
+          # both in the webhook payload; the other paths need a
+          # `gh pr view` round-trip.
           case "$EVENT_NAME" in
-            workflow_run)
-              # Empty for fork PRs (workflow_run associates pull_requests
-              # only for same-repo PRs). We bail out cleanly below.
-              num="$WORKFLOW_RUN_PR"
+            pull_request_target)
+              pr_num="$PR_EVENT_NUM"
+              head_sha="$PR_EVENT_HEAD_SHA"
               ;;
             issue_comment)
-              num="$ISSUE_COMMENT_PR"
+              pr_num="$ISSUE_COMMENT_PR"
+              head_sha=$(gh pr view "$pr_num" -R "$REPO" --json headRefOid --jq '.headRefOid')
               ;;
             workflow_dispatch)
-              num="$DISPATCH_PR"
-              ;;
-            *)
-              num=""
-              ;;
-          esac
-          if [ -z "$num" ]; then
-            echo "::notice::No PR number resolved (fork PR? push event?); skipping."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          echo "num=$num" >> "$GITHUB_OUTPUT"
-          echo "skip=false" >> "$GITHUB_OUTPUT"
-
-      - name: Author trust gate + required-check snapshot
-        id: gate
-        if: steps.pr.outputs.skip != 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-          PR_NUM: ${{ steps.pr.outputs.num }}
-          EVENT_NAME: ${{ github.event_name }}
-          # Required checks from the `main branch protection` ruleset.
-          # Newline-separated so names with spaces ("PR housekeeping")
-          # round-trip correctly. Keep in sync with the ruleset's
-          # required_status_checks and project-orchestrator.yml's
-          # bot-clean check.
-          REQUIRED_CHECKS: |
-            CI
-            PR housekeeping
-        run: |
-          set -euo pipefail
-
-          # Read draft / author / head SHA via gh pr view.
-          # - author_association is *not* a valid `gh pr view --json`
-          #   field (REST-only), fetched separately below.
-          # - statusCheckRollup is *not* fetched here: requesting it
-          #   makes GraphQL traverse `checkSuite.workflowRun` on every
-          #   check context, which the workflow's GITHUB_TOKEN can't
-          #   read for checks owned by other integrations (Gemini,
-          #   Copilot, third-party statuses). On a PR with enough
-          #   cross-integration checks the whole call fails with
-          #   "Resource not accessible by integration" even though
-          #   the data we care about is reachable. Required-check
-          #   state is fetched via REST check-runs below instead.
-          pr=$(gh pr view "$PR_NUM" -R "$REPO" \
-            --json isDraft,author,headRefOid)
-
-          if [ "$(echo "$pr" | jq -r '.isDraft')" = "true" ]; then
-            echo "::notice::PR #$PR_NUM is draft; skipping review."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          author=$(echo "$pr" | jq -r '.author.login')
-          if [ "$author" = "dependabot" ] || [ "$author" = "dependabot[bot]" ]; then
-            echo "::notice::PR #$PR_NUM is from Dependabot; skipping review."
-            echo "skip=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          association=$(gh api "repos/$REPO/pulls/$PR_NUM" --jq '.author_association')
-          # CONTRIBUTOR is included because webhook payloads report users
-          # with *private* org membership as CONTRIBUTOR (not MEMBER) even
-          # when the REST API reports them as MEMBER.
-          case "$association" in
-            OWNER|MEMBER|COLLABORATOR|CONTRIBUTOR) ;;
-            *)
-              echo "::notice::PR #$PR_NUM author $author has association $association; skipping (untrusted-actor gate)."
-              echo "skip=true" >> "$GITHUB_OUTPUT"
-              exit 0
+              pr_num="$DISPATCH_PR"
+              head_sha=$(gh pr view "$pr_num" -R "$REPO" --json headRefOid --jq '.headRefOid')
               ;;
           esac
 
-          head_sha=$(echo "$pr" | jq -r '.headRefOid')
+          # Trust gate. Fetch HEAD commit; check author and committer
+          # logins against the repo's collaborator permission map.
+          # `web-flow` is the GitHub Web UI's bot identity (in-browser
+          # editor / suggestion-accept) and has no real permission —
+          # skip it as a trust signal. Permission lookup with the
+          # integration GITHUB_TOKEN works for collaborators (incl.
+          # private org members) where REST author_association would
+          # report NONE.
+          commit=$(gh api "repos/$REPO/commits/$head_sha")
+          author_login=$(echo "$commit" | jq -r '.author.login // empty')
+          committer_login=$(echo "$commit" | jq -r '.committer.login // empty')
+
+          trusted=false
+          trust_via=""
+          for candidate in "$author_login" "$committer_login"; do
+            [ -z "$candidate" ] && continue
+            [ "$candidate" = "web-flow" ] && continue
+            [ "$candidate" = "dependabot[bot]" ] && continue
+            perm=$(gh api "repos/$REPO/collaborators/$candidate/permission" --jq '.permission' 2>/dev/null || echo "none")
+            case "$perm" in
+              admin|maintain|write|triage|read)
+                trusted=true
+                trust_via="$candidate ($perm)"
+                break
+                ;;
+            esac
+          done
+
+          if [ "$trusted" != "true" ]; then
+            echo "::notice::HEAD $head_sha: author=$author_login committer=$committer_login — neither has repo permission. Skipping Claude review."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "::notice::HEAD trusted via $trust_via. Proceeding with Claude review."
+          echo "pr_num=$pr_num" >> "$GITHUB_OUTPUT"
           echo "head_sha=$head_sha" >> "$GITHUB_OUTPUT"
-
-          # Required-check snapshot — only enforced for workflow_run.
-          # On manual triggers (issue_comment, workflow_dispatch) we
-          # honour the explicit ask even if CI is still red or running;
-          # the human has already decided they want a review.
-          #
-          # Uses the REST check-runs endpoint (filter=latest is the
-          # default, so we get one row per check name on the head
-          # commit). Status / conclusion enum values are *lowercase*
-          # in REST where GraphQL emits uppercase. Status checks
-          # (non-check_run contexts) aren't returned by this endpoint,
-          # which is fine — our required checks (CI, PR housekeeping)
-          # are both check_runs. per_page=100 is defensive against
-          # PRs that ever exceed the default page of 30 latest checks.
-          if [ "$EVENT_NAME" = "workflow_run" ]; then
-            check_runs=$(gh api \
-              "repos/$REPO/commits/$head_sha/check-runs?per_page=100" \
-              --jq '.check_runs')
-            mapfile -t CHECKS < <(printf '%s\n' "$REQUIRED_CHECKS" | awk 'NF')
-
-            for check in "${CHECKS[@]}"; do
-              entry=$(echo "$check_runs" | jq -c --arg n "$check" '.[] | select(.name == $n)' | head -n1)
-              if [ -z "$entry" ]; then
-                echo "::notice::Required check '$check' not yet present on PR #$PR_NUM; will retry on next workflow_run."
-                echo "skip=true" >> "$GITHUB_OUTPUT"
-                exit 0
-              fi
-              status=$(echo "$entry" | jq -r '.status // empty')
-              conclusion=$(echo "$entry" | jq -r '.conclusion // empty')
-              if [ "$status" != "completed" ]; then
-                echo "::notice::Required check '$check' is $status (not completed); will retry on next workflow_run."
-                echo "skip=true" >> "$GITHUB_OUTPUT"
-                exit 0
-              fi
-              case "$conclusion" in
-                success|neutral|skipped) ;;
-                failure|cancelled|timed_out|startup_failure|action_required|stale)
-                  echo "::notice::Required check '$check' concluded $conclusion; skipping Claude review (no point reviewing red CI)."
-                  echo "skip=true" >> "$GITHUB_OUTPUT"
-                  exit 0
-                  ;;
-                *)
-                  echo "::warning::Required check '$check' has unrecognised conclusion '$conclusion'; skipping defensively."
-                  echo "skip=true" >> "$GITHUB_OUTPUT"
-                  exit 0
-                  ;;
-              esac
-            done
-          fi
-
-          echo "Proceeding with Claude review (event: $EVENT_NAME)."
           echo "skip=false" >> "$GITHUB_OUTPUT"
 
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         if: steps.gate.outputs.skip != 'true'
         with:
-          # workflow_run / issue_comment / workflow_dispatch all default
-          # to checking out the default branch. Pin to the PR's head
-          # SHA so the diff Claude reviews matches the SHA that
-          # actually passed CI.
+          # pull_request_target defaults to checking out the *base*
+          # ref (main) — safe, because base-repo workflow code runs
+          # regardless. We override to PR HEAD because claude-code-action
+          # runs local git commands against the changed files. The
+          # trust gate above ensures only commits from repo-permissioned
+          # users land here, so HEAD's content is sanctioned.
           ref: ${{ steps.gate.outputs.head_sha }}
           fetch-depth: 1
 
@@ -255,7 +195,7 @@ jobs:
         if: steps.gate.outputs.skip != 'true'
         env:
           REPO: ${{ github.repository }}
-          PR_NUM: ${{ steps.pr.outputs.num }}
+          PR_NUM: ${{ steps.gate.outputs.pr_num }}
         run: |
           set -euo pipefail
           {

--- a/.github/workflows/project-orchestrator.yml
+++ b/.github/workflows/project-orchestrator.yml
@@ -63,8 +63,19 @@ on:
   # finished" signal. Use workflow_run instead — it fires regardless
   # of GITHUB_TOKEN provenance, and it's the documented way to chain
   # off another workflow completing.
+  #
+  # We listen for both `CI` and `Claude PR review` completion so the
+  # orchestrator re-evaluates after each. Bot-clean requires *all*
+  # listed checks (incl. Claude review) to be green, so:
+  #   - CI completes first → orchestrator fires → Claude still
+  #     pending → bot-clean false → skip.
+  #   - Claude review completes → orchestrator fires again →
+  #     all green → assign reviewer + set board state.
+  # If Claude fails or stays pending, the orchestrator just doesn't
+  # progress, which is the desired "wait for the AI to weigh in"
+  # behaviour.
   workflow_run:
-    workflows: [CI]
+    workflows: [CI, "Claude PR review"]
     types: [completed]
 
 permissions:
@@ -240,18 +251,49 @@ jobs:
           # Admin approval is deliberately excluded — it opens only
           # after an admin reviews, which is the step this workflow
           # triggers. Including it here would self-reference.
-          # ci.yml is a single job named "CI" running the full make-ci
-          # pipeline (lint + test + build + SDK + integration + e2e).
-          # "PR housekeeping" is the merged label + title-lint check
-          # from housekeeping.yml. Keep this list in sync with the
-          # ruleset's required_status_checks and claude-review.yml's
-          # REQUIRED_CHECKS.
-          pr=$(gh pr view "$PR_NUM" -R "$REPO" --json statusCheckRollup)
-          for check in CI "PR housekeeping"; do
-            state=$(echo "$pr" | jq -r --arg n "$check" \
-              '[.statusCheckRollup[] | select(.name == $n)] | .[0].conclusion // "MISSING"')
-            if [[ "$state" != "SUCCESS" ]]; then
-              echo "Required check '$check' is '$state'; not bot-clean yet."
+          #   - "CI" is the single job from ci.yml running make-ci.
+          #   - "PR housekeeping" is the merged label + title-lint
+          #     check from housekeeping.yml.
+          #   - "Claude review" is the AI review job from
+          #     claude-review.yml. Waiting on it here is what gives
+          #     Claude time to post its findings before we ping a
+          #     human reviewer. The job posts conclusion=success
+          #     even when its in-script trust gate skips, so PRs
+          #     from drive-by contributors don't stall here.
+          # Keep this list in sync with the ruleset's
+          # required_status_checks (note: Claude review is *not*
+          # in the ruleset — it's advisory; the orchestrator just
+          # waits for it).
+          #
+          # Reads via REST `check-runs` (filter=latest by default —
+          # one row per check name) instead of `gh pr view --json
+          # statusCheckRollup`. statusCheckRollup makes GraphQL
+          # navigate checkSuite.workflowRun across every context,
+          # which fails with "Resource not accessible by integration"
+          # on PRs that include checks from other integrations
+          # (Gemini, Copilot, third-party statuses) — same regression
+          # claude-review.yml hit in #108. REST enum values are
+          # lowercase where GraphQL emits uppercase.
+          head_sha=$(gh pr view "$PR_NUM" -R "$REPO" --json headRefOid --jq '.headRefOid')
+          check_runs=$(gh api \
+            "repos/$REPO/commits/$head_sha/check-runs?per_page=100" \
+            --jq '.check_runs')
+          for check in CI "PR housekeeping" "Claude review"; do
+            entry=$(echo "$check_runs" | jq -c --arg n "$check" '.[] | select(.name == $n)' | head -n1)
+            if [ -z "$entry" ]; then
+              echo "Required check '$check' is 'missing'; not bot-clean yet."
+              echo "clean=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            status=$(echo "$entry" | jq -r '.status // empty')
+            conclusion=$(echo "$entry" | jq -r '.conclusion // empty')
+            if [ "$status" != "completed" ]; then
+              echo "Required check '$check' is '$status' (not completed); not bot-clean yet."
+              echo "clean=false" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            if [ "$conclusion" != "success" ]; then
+              echo "Required check '$check' concluded '$conclusion'; not bot-clean yet."
               echo "clean=false" >> "$GITHUB_OUTPUT"
               exit 0
             fi


### PR DESCRIPTION
## Summary

Replaces the workflow_run-triggered Claude review with a `pull_request_target`-triggered one, switches the trust gate from "PR author association" to "HEAD commit author/committer permission", and makes the orchestrator wait for Claude review before assigning a reviewer.

Closes the chain of regressions we've been working through (#105, #108) and gives the PR a visible `Claude review` check.

## What was broken

The previous design — trigger Claude review on `workflow_run` after CI succeeds — kept producing new failures because workflow_run runs with a different token context and the check doesn't attach to the PR:

| Symptom | Root cause |
|---|---|
| `Unknown JSON field: authorAssociation` | Not a valid `gh pr view --json` field. Patched in #105. |
| `Resource not accessible by integration` (GraphQL `statusCheckRollup`) | GraphQL navigates `checkSuite.workflowRun` across every context; the workflow's GITHUB_TOKEN can't read that on PRs with other integrations' checks. Patched in #108. |
| `author_association: NONE` for jfwoods | The integration `GITHUB_TOKEN` collapses private org membership to `NONE` on REST. No good workaround at that field. |
| No `Claude review` indicator on the PR | workflow_run-triggered checks attach to the source workflow run, not the PR head commit. |
| Reviewer assigned before Claude review finished | Orchestrator was triggered by CI completion in parallel with Claude review, not after it. |

## What this PR does

### `claude-review.yml`: rebuild around `pull_request_target`

- Triggers on `pull_request_target` (open/sync/reopen/ready_for_review) plus the existing `issue_comment` and `workflow_dispatch` paths.
- Job renamed `Review` → `Claude review` — that's the check name that appears on the PR and that the orchestrator looks for. Keep them in sync.
- Workflow-level `if:` filters Dependabot at the cheap level. All other gating moves inside the job.
- Trust gate is now: `HEAD commit's author OR committer must have ≥ read permission on the repo`. Implementation:
  - `gh api repos/$REPO/commits/$head_sha` → pull `author.login`, `committer.login`.
  - For each candidate (skipping `web-flow` and `dependabot[bot]`), `gh api repos/$REPO/collaborators/$candidate/permission`.
  - First candidate whose permission is `admin/maintain/write/triage/read` wins.
- This means: if Jack opens a fork PR and I push a fixup, the next HEAD is mine → committer = me, admin → gate passes. If Jack pushes again with no admin involvement → both author and committer = Jack, no perm → gate skips. The check still posts `success` so the orchestrator can move on (drive-by PRs still get a human reviewer assigned, just without AI auto-review).
- Required-check snapshot (the part that fetched check-runs and gated on CI success) is gone. Claude can review red CI; it can read the failing diff and say so. The merge gate is still the branch ruleset, not this workflow.
- ~80 lines of gate scaffolding deleted overall.

### `project-orchestrator.yml`: wait for Claude review

- `workflow_run.workflows: [CI]` → `[CI, "Claude PR review"]`. Orchestrator re-fires when Claude completes.
- Bot-clean required-checks list gains `Claude review`. First firing (after CI) sees Claude pending → bot-clean false → skip. Second firing (after Claude) sees all green → assign reviewer + set board state.
- Bot-clean switches from `gh pr view --json statusCheckRollup` to REST `check-runs`, pre-empting the same GraphQL `Resource not accessible by integration` failure that hit `claude-review.yml` in #108. PR #7 wasn't tripping it yet; PR #88 (with Gemini) would have.

`Claude review` is *not* added to the branch ruleset's `required_status_checks` — it's advisory. The orchestrator just waits for it locally.

## Behavioural changes worth flagging

- **Drafts are now reviewed.** Previously the gate skipped drafts; the new gate doesn't filter on draft state. The orchestrator's existing draft → ready auto-flip still works (gated on bot-clean, which now includes Claude). Easy to add back a draft-filter inside the gate step if it turns out to be noisy.
- **Claude reviews red CI.** It can read the failing diff and comment on it. Saves the "wait for CI, then review" round-trip; costs a few API calls on PRs that get force-pushed before CI finishes.
- **Drive-by fork PRs skip Claude but the check still appears.** Conclusion is `success` with a notice in the step log explaining the skip. The orchestrator treats this as "Claude weighed in" and proceeds to assign a human reviewer.

## Test plan

- [ ] Internal PR pushed by a private-org member: `Claude review` check appears on the PR; orchestrator waits for it before assigning.
- [ ] Fork PR by a drive-by contributor: `Claude review` posts `success (skipped)`; orchestrator still assigns a reviewer.
- [ ] Admin commits a fixup onto a fork PR: next push re-runs Claude review against the new HEAD with trust via committer.
- [ ] `@claude` / `/review` re-trigger via comment still works.
- [ ] Dependabot PR: filtered at workflow-level `if:`, no Claude check on PR, dependabot-automerge path handles it as before.
- [ ] PR #88-style cross-integration check list: orchestrator's bot-clean no longer hits GraphQL Resource-not-accessible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)