### PR TITLE
fix(ci): claude-review trigger pull_request_target → pull_request

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -5,16 +5,21 @@ name: Claude PR review
 # `/review` comments and the workflow_dispatch button.
 #
 # Triggers:
-#   pull_request_target — fires on every PR open/sync/reopen/
+#   pull_request        — fires on every PR open/sync/reopen/
 #                         ready-for-review immediately, not after CI.
 #                         The job's check appears in the PR's Checks
 #                         panel natively — no manual status posting.
-#                         `pull_request_target` (not `pull_request`)
-#                         because the Anthropic action needs the
-#                         CLAUDE_CODE_OAUTH_TOKEN secret and write
-#                         scope, which `pull_request` denies on fork
-#                         PRs. The trust gate below is what makes
-#                         that safe.
+#                         `pull_request_target` doesn't work here:
+#                         the Anthropic action's OIDC token exchange
+#                         rejects pull_request_target's OIDC claims
+#                         (upstream issue #713). With `pull_request`,
+#                         secrets are *not* available for fork PRs —
+#                         that means Claude can't auto-review a PR
+#                         from a drive-by contributor, but it also
+#                         means the action can never run with PR-
+#                         supplied code holding write tokens.
+#                         Internal PRs (the dominant case) work fine
+#                         because secrets are accessible.
 #   issue_comment       — manual re-trigger when a trusted reviewer
 #                         types `@claude` or `/review` in a PR
 #                         comment.
@@ -53,7 +58,7 @@ name: Claude PR review
 # review-thread resolution) is the actual merge gate.
 
 on:
-  pull_request_target:
+  pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
   issue_comment:
     types: [created]
@@ -86,7 +91,7 @@ jobs:
     # opener and miss this.
     if: |
       (
-        github.event_name == 'pull_request_target'
+        github.event_name == 'pull_request'
         && github.event.pull_request.user.login != 'dependabot[bot]'
       ) || (
         github.event_name == 'issue_comment'
@@ -117,11 +122,11 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Resolve PR number + HEAD SHA. pull_request_target gives us
-          # both in the webhook payload; the other paths need a
+          # Resolve PR number + HEAD SHA. pull_request gives us both
+          # in the webhook payload; the other paths need a
           # `gh pr view` round-trip.
           case "$EVENT_NAME" in
-            pull_request_target)
+            pull_request)
               pr_num="$PR_EVENT_NUM"
               head_sha="$PR_EVENT_HEAD_SHA"
               ;;
@@ -177,12 +182,12 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         if: steps.gate.outputs.skip != 'true'
         with:
-          # pull_request_target defaults to checking out the *base*
-          # ref (main) — safe, because base-repo workflow code runs
-          # regardless. We override to PR HEAD because claude-code-action
-          # runs local git commands against the changed files. The
-          # trust gate above ensures only commits from repo-permissioned
-          # users land here, so HEAD's content is sanctioned.
+          # pull_request defaults to checking out the PR's merge ref
+          # (a temporary merge of PR HEAD into base). Pin to the PR
+          # HEAD SHA explicitly so claude-code-action sees exactly
+          # the user's commit, not a merge artefact. The trust gate
+          # above ensures only commits from repo-permissioned users
+          # land here.
           ref: ${{ steps.gate.outputs.head_sha }}
           fetch-depth: 1
 


### PR DESCRIPTION
## Summary

Follow-up to #109. The Anthropic action's OIDC token exchange rejects `pull_request_target`'s OIDC claims and we hit `App token exchange failed: 401 Unauthorized - Invalid OIDC token` on the first run. This is upstream issue [anthropics/claude-code-action#713](https://github.com/anthropics/claude-code-action/issues/713) (open). Their docs (`docs/solutions.md` > "Automatic PR Code Review") use `pull_request`, not `pull_request_target`. Switching to that.

## What changes

- Trigger: `pull_request_target` → `pull_request`. Same event types.
- `if:` and the in-script case dispatch use `pull_request` instead of `pull_request_target`.
- Checkout comment updated: `pull_request` defaults to the PR's *merge* ref; we keep explicitly pinning to PR HEAD so the action sees the commit, not a merge artefact.

## Trade-off (worth knowing)

`pull_request` runs from a fork PR with a **read-only** GITHUB_TOKEN and **no access to repo secrets**. Practical impact:

- Internal PRs (the dominant case on this repo) — fine. Secrets accessible.
- Fork PRs from drive-by contributors — trust gate still skips them cleanly, conclusion=success, orchestrator's bot-clean isn't disrupted.
- Fork PRs where an admin pushes a fixup commit — HEAD-committer trust gate passes, but the action then fails to authenticate because `CLAUDE_CODE_OAUTH_TOKEN` is empty in fork-PR contexts. This case wasn't supported before either (workflow_run was the prior trigger and fork PRs don't populate `workflow_run.pull_requests`), so this is a wash, not a regression.

## Why not solve fork support some other way

The upstream pattern for fork-PR review is a two-workflow split: a `pull_request` workflow that posts a "pending" status, and a `workflow_run`/`pull_request_target` follow-up that runs the review with elevated tokens. That's exactly the chain we just removed in #109 because it kept breaking. Not worth re-introducing for a case we don't actually have.

## Test plan

- [ ] Next push to PR #7 (or any internal PR): `Claude review` check appears and completes successfully.
- [ ] Orchestrator waits for the Claude check before assigning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)