### PR TITLE
fix(ci): claude bot's own comment shouldn't cancel its in-flight review

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -70,11 +70,16 @@ on:
         type: string
 
 # Dedup per PR. PR number reachable from each event payload before
-# any step runs. `cancel-in-progress: true` means a fast-follow push
-# replaces an in-flight review with one against the new HEAD.
+# any step runs. Fast-follow human action (new push, /review comment)
+# cancels an in-flight review against the now-stale HEAD. Bot-triggered
+# events do NOT cancel — otherwise Claude's own sticky comment fires
+# an `issue_comment created` webhook that would cancel the in-flight
+# review-run as it's still finishing posting. The new bot-triggered
+# run is filtered out at the job-level `if:` anyway, so making it
+# non-cancelling here just lets the original run complete.
 concurrency:
   group: claude-review-${{ github.event.pull_request.number || github.event.issue.number || inputs.pr_number || github.run_id }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event.sender.type != 'Bot' }}
 
 jobs:
   review:


### PR DESCRIPTION
## What's happening

When Claude review runs on a PR push, it ends by posting a sticky review comment. That comment fires an `issue_comment created` webhook, which re-fires the `Claude PR review` workflow. The new run is in the same concurrency group as the still-in-flight pull_request run, so `cancel-in-progress: true` cancels the original — *while it's still finalising the comment it just posted*. The new run then evaluates the job-level `if:` (comment body doesn't contain @claude or /review) and skips, but the damage is done: the original run shows as `cancelled` on the PR and any post-comment cleanup the action wanted to do gets cut.

Observed on PR #7:
- `25736516663` (pull_request, 13:08:39) → **cancelled**
- `25736559325` (issue_comment, 13:09:26) → skipped (no @claude/`/review` match)

## Fix

Make `cancel-in-progress` an expression: `${{ github.event.sender.type != 'Bot' }}`.

- Human pushes a new commit or types `/review` → `sender.type == 'User'` → `cancel-in-progress: true` → stale run cancelled, same as before.
- Claude (or any other Bot account) triggers an `issue_comment` → `sender.type == 'Bot'` → `cancel-in-progress: false` → the in-flight run finishes; the bot-triggered run still gets filtered out at the job-level `if:` and skips harmlessly.

## Test plan

- [ ] Push a commit to a PR → Claude review runs to completion and the run shows as `success` (not `cancelled`).
- [ ] Push two commits in quick succession → second push cancels the first run as before (human → human).
- [ ] Manually type `/review` while a review is in progress → still cancels (intended — user explicitly asked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)