### PR TITLE
fix(query): format time_range bounds as ClickHouse DateTime

### DIFF
--- a/internal/query/builder.go
+++ b/internal/query/builder.go
@@ -233,6 +233,10 @@ func filterToSQL(f Filter) (string, []any, error) {
 // The clickhouse-go driver's time.Time formatting uses toDateTime() (second
 // precision), which loses milliseconds needed for DateTime64 cursor comparisons.
 // Returning a formatted string lets ClickHouse parse it with full precision.
+//
+// A value that isn't a timestamp (a plain string, a number, etc.) is a valid
+// non-temporal filter value, so the parse "failure" is just the expected
+// non-timestamp case — pass it through unchanged rather than treat it as an error.
 func coerceFilterValue(v any) any {
 	s, ok := v.(string)
 	if !ok {
@@ -257,7 +261,7 @@ func formatClickHouseTime(t time.Time) string {
 // resolveTimeValue parses an RFC3339 timestamp or a relative duration like "1h",
 // "30m" and renders it as a ClickHouse DateTime literal (see formatClickHouseTime).
 // When bucketSeconds > 0, timestamps are bucketed (truncated) to the nearest
-// boundary. Failure to parse returns the original string, which will likely
+// boundary. An unrecognised value is returned unchanged, which will likely
 // cause a ClickHouse error.
 //
 // The output deliberately matches coerceFilterValue's format rather than RFC3339:
@@ -267,7 +271,8 @@ func resolveTimeValue(val string, bucketSeconds int) string {
 	if d, err := time.ParseDuration(val); err == nil {
 		return formatClickHouseTime(bucketTime(time.Now().UTC().Add(-d), bucketSeconds))
 	}
-
+	// Try an absolute timestamp (RFC3339Nano accepts fractional and whole-second
+	// input); normalise to UTC before bucketing.
 	if t, err := time.Parse(time.RFC3339Nano, val); err == nil {
 		return formatClickHouseTime(bucketTime(t.UTC(), bucketSeconds))
 	}

--- a/internal/query/builder.go
+++ b/internal/query/builder.go
@@ -238,31 +238,38 @@ func coerceFilterValue(v any) any {
 	if !ok {
 		return v
 	}
+	// RFC3339Nano parses both fractional and whole-second RFC3339 input.
 	if t, err := time.Parse(time.RFC3339Nano, s); err == nil {
-		return t.UTC().Format("2006-01-02 15:04:05.999999999")
-	}
-	if t, err := time.Parse(time.RFC3339, s); err == nil {
-		return t.UTC().Format("2006-01-02 15:04:05")
+		return formatClickHouseTime(t)
 	}
 	return v
 }
 
-// resolveTimeValue parses an RFC3339 timestamp or a relative duration like "1h", "30m".
-// When bucketSeconds > 0, timestamps are bucketed (truncated) to the nearest boundary.
-// Failure to parse returns the original string, which will likely cause a ClickHouse error.
+// clickHouseDateTimeLayout renders a time in ClickHouse's native DateTime text
+// format. The fractional ".999999999" preserves sub-second precision when
+// present and drops trailing zeros, so a whole-second time has no decimal point.
+const clickHouseDateTimeLayout = "2006-01-02 15:04:05.999999999"
+
+func formatClickHouseTime(t time.Time) string {
+	return t.UTC().Format(clickHouseDateTimeLayout)
+}
+
+// resolveTimeValue parses an RFC3339 timestamp or a relative duration like "1h",
+// "30m" and renders it as a ClickHouse DateTime literal (see formatClickHouseTime).
+// When bucketSeconds > 0, timestamps are bucketed (truncated) to the nearest
+// boundary. Failure to parse returns the original string, which will likely
+// cause a ClickHouse error.
+//
+// The output deliberately matches coerceFilterValue's format rather than RFC3339:
+// a bare "…T…Z" string is rejected by DateTime64 columns.
 func resolveTimeValue(val string, bucketSeconds int) string {
 	// Try relative duration first (e.g., "1h", "30m", "5m").
 	if d, err := time.ParseDuration(val); err == nil {
-		t := time.Now().UTC().Add(-d)
-		return bucketTime(t, bucketSeconds).Format(time.RFC3339)
+		return formatClickHouseTime(bucketTime(time.Now().UTC().Add(-d), bucketSeconds))
 	}
-	// Try RFC3339 timestamp.
-	if t, err := time.Parse(time.RFC3339, val); err == nil {
-		return bucketTime(t, bucketSeconds).Format(time.RFC3339)
-	}
-	// Try RFC3339Nano.
+
 	if t, err := time.Parse(time.RFC3339Nano, val); err == nil {
-		return bucketTime(t, bucketSeconds).Format(time.RFC3339)
+		return formatClickHouseTime(bucketTime(t.UTC(), bucketSeconds))
 	}
 	return val
 }

--- a/internal/query/builder_test.go
+++ b/internal/query/builder_test.go
@@ -241,19 +241,23 @@ func TestResolveTimeValue_RelativeDuration(t *testing.T) {
 	result := resolveTimeValue("1h", 0)
 	assert.NotEmpty(t, result)
 	assert.NotEqual(t, "1h", result, "relative duration should resolve to a timestamp")
+
+	assert.NotContains(t, result, "T", "must not emit the RFC3339 T separator")
+	assert.NotContains(t, result, "Z", "must not emit the RFC3339 Z zone suffix")
 }
 
 func TestResolveTimeValue_RFC3339(t *testing.T) {
 	t.Parallel()
+
 	result := resolveTimeValue("2024-01-01T00:00:00Z", 0)
-	assert.Equal(t, "2024-01-01T00:00:00Z", result)
+	assert.Equal(t, "2024-01-01 00:00:00", result)
 }
 
 func TestResolveTimeValue_WithBucketing(t *testing.T) {
 	t.Parallel()
 	// With 60s buckets, a time at :30 should truncate to :00.
 	result := resolveTimeValue("2024-01-01T12:34:30Z", 60)
-	assert.Equal(t, "2024-01-01T12:34:00Z", result)
+	assert.Equal(t, "2024-01-01 12:34:00", result)
 }
 
 func TestBucketTime_ZeroBucket(t *testing.T) {
@@ -396,6 +400,28 @@ func TestBuild_TimeRange_SinceOnly(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, result.SQL, "ts >= ?")
 	assert.NotContains(t, result.SQL, "ts <= ?")
+}
+
+func TestBuild_TimeRange_ClickHouseDateTimeFormat(t *testing.T) {
+	t.Parallel()
+	sq := &StructuredQuery{
+		Columns: []string{"page"},
+		TimeRange: &TimeRange{
+			Column: "ts",
+			Since:  "2024-01-01T00:00:00Z",
+			Until:  "2024-01-02T03:04:05Z",
+		},
+	}
+	result, err := Build("clicks", sq, testSchema(), 0)
+	require.NoError(t, err)
+	require.Len(t, result.Params, 2)
+	assert.Equal(t, "2024-01-01 00:00:00", result.Params[0])
+	assert.Equal(t, "2024-01-02 03:04:05", result.Params[1])
+	for _, p := range result.Params {
+		s, ok := p.(string)
+		require.True(t, ok, "time_range bound must be a formatted string param")
+		assert.NotContains(t, s, "T", "must not bind an RFC3339 T-separated string (#238)")
+	}
 }
 
 func TestBuild_FilterUnsupportedOp(t *testing.T) {

--- a/tests/e2e/sdk/query.test.ts
+++ b/tests/e2e/sdk/query.test.ts
@@ -1,5 +1,13 @@
 import { beforeAll, describe, expect, it } from "vitest";
-import { adminClient, chQuery, dataClient, testId, waitForCondition } from "./helpers.js";
+import {
+  adminClient,
+  chQuery,
+  dataClient,
+  makeJWT,
+  testId,
+  WH_URL,
+  waitForCondition,
+} from "./helpers.js";
 import { suiteTables } from "./tables.js";
 
 describe("Query", () => {
@@ -56,6 +64,27 @@ describe("Query", () => {
       expect(row).toHaveProperty("page");
       expect(row).toHaveProperty("duration_ms");
     }
+  });
+
+  it("time_range over a DateTime64 column does not 500 (#238)", async () => {
+    const jwt = makeJWT({ sub: "test-viewer", role: "viewer", tenant_id: "acme" });
+    const res = await fetch(`${WH_URL}/v1/query?table=${encodeURIComponent(T.clicks)}`, {
+      method: "POST",
+      headers: { "content-type": "application/json", authorization: `Bearer ${jwt}` },
+      body: JSON.stringify({
+        columns: ["event_id", "page"],
+        time_range: { column: "received_timestamp", since: "24h" },
+      }),
+    });
+
+    // The bug surfaced as HTTP 500 (ClickHouse code 53); the fix returns 200.
+    expect(res.status).toBe(200);
+    const rows = (await res.json()) as unknown[];
+    expect(Array.isArray(rows)).toBe(true);
+    // The rows seeded in beforeAll all carry received_timestamp = now64(3), so a
+    // "last 24h" window must return at least those — proving the bound actually
+    // matched DateTime64 values rather than just returning an empty 200.
+    expect(rows.length).toBeGreaterThanOrEqual(seededIds.length);
   });
 
   it("aggregation: count with groupBy", async () => {


### PR DESCRIPTION
## Summary
`time_range` `since`/`until` flowed through `resolveTimeValue`, which formatted timestamps as RFC3339 (`2026-06-03T10:23:00Z`) and bound them as strings. ClickHouse won't implicitly coerce that `T…Z` shape into a `DateTime64`, so **every** `time_range` query against the dominant timestamp type 500'd with code 53 — for both relative (`"24h"`) and absolute inputs. Regular `filters` worked only because `coerceFilterValue` already emitted ClickHouse's native space-separated `DateTime` form; the two timestamp paths had simply drifted.

This unifies both paths through a single `formatClickHouseTime` helper that emits ClickHouse-native `2006-01-02 15:04:05.999999999` (UTC), so they can't diverge again. Two latent issues in the old `resolveTimeValue` go away with it: it now normalizes to UTC *before* bucketing, and it no longer drops sub-second precision on absolute inputs. No API change — `since`/`until` still accept RFC3339 or relative strings; only the outbound format to ClickHouse changed.

## Test plan
- [x] `go test ./...` — updated the two `resolveTimeValue` unit tests that encoded the bug, plus a new `Build`-level guard (`TestBuild_TimeRange_ClickHouseDateTimeFormat`) asserting bound params are ClickHouse-native, never RFC3339.


## Related Issues
Closes #238

<!--
Checklist for the author (not kept in the squash commit message):

- `make ci` passes locally
- Docs updated per AGENTS.md "Documentation & Consistency Sync" rules
- CHANGELOG.md [Unreleased] entry added
- Tests cover new / changed behavior (70 % minimum, 80 %+ preferred)

The PR title is the squash commit subject — use Conventional Commits
(`feat:`, `fix:`, `docs:`, `refactor:`, `test:`, `chore:`, `ci:`,
`deps:`, `build:`, `perf:`, `revert:`, `style:`). The PR body below is
the squash commit message, so keep it tight.
-->
