### PR TITLE
chore(pm-triage): add safe-auto 'all' routine mode + local state branch

### DIFF
--- a/.claude/skills/pm-triage/SKILL.md
+++ b/.claude/skills/pm-triage/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pm-triage
-description: Project-manager review for WaveHouse issues — triage dogfooding feedback logs, re-classify the backlog P0–P3 (launch-gated), sweep code TODOs, and reconcile issue/PR status into well-scoped, tracked GitHub issues on the Task Board (project #7). Use when the user wants to triage feedback or the backlog, file/update issues from a feedback doc or TODOs, re-prioritize, edit titles/bodies or add follow-up comments, or check that work is actually tracked. Invoke as `/pm-triage [feedback-doc <url|path> | backlog | todos | status]`. Propose-first by default; add `auto` to run end-to-end.
+description: Project-manager review for WaveHouse issues — triage dogfooding feedback logs, re-classify the backlog P0–P3 (launch-gated), sweep code TODOs, and reconcile issue/PR status into well-scoped, tracked GitHub issues on the Task Board (project #7). Use when the user wants to triage feedback or the backlog, file/update issues from a feedback doc or TODOs, re-prioritize, edit titles/bodies or add follow-up comments, or check that work is actually tracked. Invoke as `/pm-triage [feedback-doc <url|path> | backlog | todos | status | all]`. **safe-auto by default** (auto-apply low-risk changes; for risky ones — ask when you're watching, queue to `pending.md` when unattended); add `auto` (apply everything), `report-only` (write nothing), or `propose` (review even safe changes). `all` is the daily local routine (status+backlog+todos, incremental); state on a local-only orphan branch `pm-triage-state`. See `references/routine.md`.
 ---
 
 # PM triage for WaveHouse
@@ -9,9 +9,10 @@ Turn raw inputs — dogfooding logs, the open-issue backlog, code TODOs, PR/issu
 
 **Run modes:**
 
-- **propose-first** (default) — validate, present the plan (new issues, edits, reclassifications, comments) for approval, then execute.
-- **`auto`** — run end-to-end and report at the end (the behavior this skill was distilled from). For when you're watching and want it to just go.
-- **`report-only`** — validate and emit the full plan as the output, **write nothing**. This is the right mode for an **unattended/scheduled** run: there's no one to approve mid-run, so produce the triage report (and post it as a comment on the launch tracker if asked) for a human to action later.
+- **`safe-auto`** (default) — auto-apply the **safe tier** (set *missing* priorities, fix board Status to reality, file clearly-new issues with provenance, tick epic boxes for closed issues). For the **risky tier** (teammate priority changes, security/disclosure, closes/dupes, body edits, cross-repo writes): **ask** when a human's in the session, **queue** to the state branch's `pending.md` when unattended. Never apply risky changes unattended. Reads/writes the local state branch (`## Mode: all`).
+- **`auto`** — apply everything, including the risky tier, without asking. For when you're watching and fully trust it.
+- **`report-only`** — emit the full plan as output, **write nothing** (no GitHub writes, no state commit). The **dry-run / preview** mode.
+- **`propose`** — fully interactive: present *everything* (even safe-tier changes) for approval before doing it. Use when you want eyes on every change.
 
 ## Modes (the argument)
 
@@ -19,6 +20,7 @@ Turn raw inputs — dogfooding logs, the open-issue backlog, code TODOs, PR/issu
 - **`backlog`** — re-classify every open issue P0–P3 (launch-gated) on the board.
 - **`todos`** — sweep code `TODO/FIXME/HACK/XXX` for untracked-worth-tracking items.
 - **`status`** — reconcile open issues **and PRs**: stale items, untracked work, un-updated threads.
+- **`all`** — `status` + `backlog` + `todos` in one **incremental** pass (the routine scope), diffed against the state branch's last run. Excludes `feedback-doc` (needs an explicit doc); point the routine at known feedback logs separately if wanted. See `## Mode: all (the routine)`.
 - No arg → ask which, or infer from what the user just referenced.
 
 ## Operating conventions (every mode)
@@ -61,12 +63,34 @@ Turn raw inputs — dogfooding logs, the open-issue backlog, code TODOs, PR/issu
 2. Flag: open PRs with no tracking issue / stale (no update in N days) / out-of-date-with-main; issues with open PRs that should be linked; epic checkboxes whose issues closed (tick them); board items whose Status drifted from reality (closed issue not Done, etc.).
 3. Propose the reconciling edits (comments, board status, checkbox ticks). Don't mass-comment.
 
+## Mode: all (the routine)
+
+`status` + `backlog` + `todos` in one pass, **incremental** against the local state branch, with the default `safe-auto` policy. This is the daily local routine (Claude desktop app, runs on your Mac — not cloud). Full procedure + the paste-ready routine prompt: `references/routine.md`.
+
+**Durable state — a local-only orphan branch (not an issue, not a cache dir).** `scripts/state.sh` keeps state on an orphan branch `pm-triage-state` (shares no history with main; never pushed by default → private), in its own worktree at `<main>/.worktrees/pm-triage-state` (path is stable across all your worktrees). **Never switch branches in a working tree — navigate by path:**
+
+- `state.sh ensure` → create-if-needed, echoes the worktree path `S`.
+- `state.sh read` → `state.json` (`{ schema, last_run_at, last_sha, filed }`, `filed` = fingerprint→issue#); `{}` on first run = full sweep.
+- Write `S/state.json` via `state.sh write` (preserve `schema`); write `S/pending.md` (risky items) and `S/runs.log` directly — `state.sh commit` stages all three.
+- `state.sh commit "<summary>"` after a meaningful run → a versioned audit trail you can `git -C S log`.
+
+**Read code without disturbing any tree.** `git fetch origin`, then do TODO sweeps / code-read validation against **`origin/main`** by ref (`git grep`, `git show`, `git diff <last_sha>..origin/main`) — don't assume or mutate a working tree, don't checkout.
+
+**Write tiers (`safe-auto`).** Apply the SAFE tier; for the RISKY tier — **ask** if a human's in the session, else **queue** to `S/pending.md`. Never apply risky unattended:
+
+| SAFE (auto) | RISKY (ask if watching · else queue to pending.md) |
+|---|---|
+| set a *missing* Priority; fix Status to reality; file a clearly-new issue (dedupe first, provenance, ≤8/run); tick epic boxes for closed issues | change a teammate-set priority; security/disclosure; close/dupe/merge-into-epic; edit a body or comment on a teammate's issue; any cross-repo write |
+
+**Rails.** Dedupe before filing (conv. #9); `state.json.filed` (fingerprint→issue#) also stops re-filing across runs. Cap new issues at **8/run** (the rest are re-found next run). At start, surface any open `pending.md` items. The routine creates real GitHub issues + sets board fields as always — only its **own bookkeeping** moved to the local branch. Inherit the `.claude/settings.json` deny-list (never merge PRs, never `gh pr ready`).
+
 ## Scripts
 
 - **`scripts/board.sh`** — race-safe board ops. Subcommands:
   - `file <P0|P1|P2|P3> <Backlog|Ready|InProgress|InReview|Done> "<labels>" "<title>"` (body on stdin) → creates the issue, waits out the auto-add workflow, sets Priority + Status, echoes the number.
   - `set-priority <issue#> <P0..P3>` · `set-status <issue#> <Status>` · `item-id <issue#>` · `open-by-priority`.
   - Field/option IDs are baked in (verified) and overridable by env (`WH_PROJECT_ID`, `WH_PRIORITY_FIELD`, …) if the board changes.
+- **`scripts/state.sh`** — local-only routine state on the orphan branch `pm-triage-state` in its own worktree (private, never pushed, stable across worktrees, versioned audit trail; see `## Mode: all`). `ensure` (create-if-needed, echoes worktree path) · `path` · `read`/`write` (state.json) · `commit "<msg>"`.
 
 When filing many issues at once, prefer: create them all (capture numbers), **then** one board pass that looks up item ids and sets fields — fewer auto-add races than per-issue.
 

--- a/.claude/skills/pm-triage/references/routine.md
+++ b/.claude/skills/pm-triage/references/routine.md
@@ -1,0 +1,126 @@
+# Running `/pm-triage all` as a local routine
+
+The scheduled form of pm-triage: a daily local pass that reconciles status, re-checks the
+backlog, and sweeps new TODOs — applying safe changes itself and surfacing risky ones. Scope
+`all`, default run-mode `safe-auto`. Runs on your Mac (only when it's on — that's fine), set up
+as a routine in the **Claude desktop app**. It is **not** a cloud routine (this repo's gates,
+`gh` auth, and `make ci` deps don't exist in the cloud) and **not** a launchd / `claude -p` job.
+
+## State: a local-only orphan branch
+
+State lives on an **orphan branch `pm-triage-state`** — shares no history with main (its own
+thing), checked out in its own worktree at `<main>/.worktrees/pm-triage-state`, **never pushed
+by default** (private; teammates can't see an unpushed branch). `scripts/state.sh` manages it.
+Why this over the alternatives:
+
+- **vs. a GitHub issue:** no API round-trips, no notifications, no teammate comments — the logic stays private.
+- **vs. `.git/pm-triage/`:** a real branch is legible and idiomatic, and it's versioned.
+- **vs. a plain gitignored dir:** untracked files are *per-worktree*, so a `.claude/pm-triage/` would fork across your 7 worktrees. The orphan worktree is one registered path, identical from everywhere.
+
+You get a **versioned audit trail** — each meaningful run commits, so `git -C <state-wt> log`
+shows when it changed what — and an easy **future sync** path: flip on `git push -u origin
+pm-triage-state` to share across machines (left OFF for now).
+
+**No branch-switching, ever.** The skill never `git checkout`s between main and the state
+branch in one tree (that swaps your whole working dir and breaks on uncommitted work). It
+navigates by **path**: file I/O in the state worktree, and code/TODO reads against `origin/main`
+by ref (`git fetch`, then `git grep` / `git diff <last_sha>..origin/main`).
+
+Files in the state worktree:
+
+- `state.json` — `{ schema, last_run_at, last_sha, filed }`; `filed` is the fingerprint→issue# dedupe index, so it never re-files.
+- `pending.md` — risky proposals awaiting you (human-editable; resolve them and the next run reconciles).
+- `runs.log` — append-only, one line per run.
+
+`state.json` goes through `state.sh write` (validated, atomic); `pending.md` and `runs.log` are written directly, and `state.sh commit` stages all three.
+
+## safe-auto is the default (every invocation)
+
+The safe tier just happens — no proposal step — whether you run it by hand or it fires on
+schedule. Only the risky tier flexes:
+
+- **You're watching** (manual `/pm-triage …`): it presents risky items and asks you right there.
+- **Unattended** (the routine): it appends them to `pending.md` for you to review later.
+
+| SAFE — auto | RISKY — ask if watching · else queue to `pending.md` |
+|---|---|
+| set a **missing** Priority; fix **Status** to reality; file a **clearly-new** issue (dedupe, provenance, ≤8/run); tick epic boxes for closed issues | change a teammate-set priority; security/disclosure; close/dupe/merge-into-epic; edit a body or comment on a teammate's issue; any cross-repo write |
+
+(`auto` = don't even ask on risky; `report-only` = dry run, writes nothing; `propose` = review even the safe changes.)
+
+## Cadence
+
+Daily, weekday mornings. In the routine's schedule pick an off-`:00` minute (e.g. 9:07) so
+you're not landing on the same instant as everyone else.
+
+## Set it up in the Claude desktop app
+
+1. Open the WaveHouse repo as a local project in the desktop app, so the routine has the repo,
+   your keychain'd `gh`, and the `.claude/` skill.
+2. Create a routine / scheduled task on a weekday-morning schedule and paste the prompt below.
+3. **On the first run, verify:** it read the skill (`SKILL.md`), `gh auth status` is good, and it
+   created the state worktree. Approve the `gh` / `git` / file tools it needs — or pre-grant them:
+
+### Permissions (so an unattended run doesn't stop on a prompt)
+
+Pre-grant the reads/writes in **`.claude/settings.local.json`** (gitignored, per-user — *not*
+the shared `settings.json`). The shared `deny` list still blocks the dangerous ops, and `deny`
+beats `allow`:
+
+```jsonc
+// .claude/settings.local.json  (gitignored — personal)
+{
+  "permissions": {
+    "allow": [
+      "Bash(gh issue create:*)", "Bash(gh issue edit:*)", "Bash(gh issue comment:*)",
+      "Bash(gh issue list:*)", "Bash(gh issue view:*)",
+      "Bash(gh pr list:*)", "Bash(gh pr view:*)",
+      "Bash(gh project item-list:*)", "Bash(gh project item-edit:*)",
+      "Bash(gh project field-list:*)", "Bash(gh project item-add:*)",
+      "Bash(git fetch:*)", "Bash(git grep:*)", "Bash(git diff:*)", "Bash(git log:*)",
+      "Bash(bash .claude/skills/pm-triage/scripts/board.sh:*)",
+      "Bash(bash .claude/skills/pm-triage/scripts/state.sh:*)"
+    ]
+  }
+}
+```
+
+(Rules are prefix matches on the exact command string; the script rules assume the
+`bash .claude/skills/pm-triage/scripts/<name>.sh …` form the prompt uses.)
+
+## Dry run first (writes nothing)
+
+```text
+/pm-triage all report-only
+```
+
+## The routine prompt (paste into the desktop routine)
+
+> You are running the WaveHouse PM-triage daily routine, on the local machine, in the
+> `Wave-RF/WaveHouse` repo. The procedure's source of truth is
+> `.claude/skills/pm-triage/SKILL.md` — read and follow it. Scope: `all`. Run-mode: `safe-auto`,
+> **UNATTENDED** (no human is watching — do NOT ask; queue risky items instead of applying them).
+>
+> 1. Resolve state: `bash .claude/skills/pm-triage/scripts/state.sh ensure` → state worktree
+>    path `S`. Read `S/state.json` (`{schema,last_run_at,last_sha,filed}`) and `S/pending.md`.
+> 2. `git fetch origin`. Do all code/TODO reads against `origin/main` by ref (`git grep`,
+>    `git diff <last_sha>..origin/main`) — never checkout or switch branches.
+> 3. Triage incrementally since `last_sha`/`last_run_at` (full sweep if state is empty):
+>    **status** (open issues + PRs vs board #7), **backlog** (launch-gated P0–P3 per
+>    `references/rubric.md` for new/changed issues + any missing a priority), **todos**
+>    (new/changed `TODO|FIXME|HACK|XXX` since `last_sha`).
+> 4. Apply the SAFE tier automatically (set *missing* priorities; fix board Status to reality;
+>    file clearly-new issues — dedupe against `filed` + live issues/PRs first, provenance footer,
+>    ≤8/run; tick epic boxes for closed issues). Use `scripts/board.sh` for board writes.
+> 5. Queue the RISKY tier to `S/pending.md` (teammate priority changes, security/disclosure,
+>    closes/dupes, body edits, cross-repo) — do NOT apply unattended.
+> 6. Update state: write `S/state.json` (keep `schema`; `last_run_at`=now, `last_sha`=`git rev-parse
+>    origin/main`; extend `filed` with anything you filed), refresh `S/pending.md` (drop items you can
+>    see were resolved), append a line to `S/runs.log`, then
+>    `bash .claude/skills/pm-triage/scripts/state.sh commit "<one-line summary>"`.
+> 7. If nothing changed, still write `last_run_at`/`last_sha` but skip the commit.
+>
+> Follow every operating convention in SKILL.md; respect `.claude/settings.json`'s deny-list
+> (never merge PRs, never `gh pr ready`). End with a short summary: counts (filed /
+> priority-set / status-fixed), the launch-blocking shortlist (P0/P1), and how many items are in
+> `pending.md` awaiting you.

--- a/.claude/skills/pm-triage/scripts/state.sh
+++ b/.claude/skills/pm-triage/scripts/state.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# Local, private, cross-worktree state for the /pm-triage routine.
+#
+# State lives on a dedicated ORPHAN branch ("pm-triage-state") that shares NO history with
+# main (its own thing), checked out in its own worktree at <main>/.worktrees/pm-triage-state.
+# The skill does plain file I/O there and commits after meaningful runs, so you get a local
+# audit trail ("see when it changed things"). The branch is LOCAL ONLY — never pushed by
+# default, so teammates can't see it; flip publishing on later for cross-machine sync.
+#
+# No branch-switching ever happens in your working trees: the state worktree is a separate
+# path, and the skill reads code/TODOs from origin/main by ref (git grep / git diff). The
+# worktree path derives from the shared git common dir, so it's identical from every worktree.
+#
+# Files in the state worktree:
+#   state.json   {schema,last_run_at,last_sha,filed:{<fingerprint>:<issue#>}}
+#   pending.md   risky proposals awaiting a human decision (human-editable)
+#   runs.log     append-only, one line per run
+#
+# Subcommands:
+#   ensure          create the orphan branch + worktree if absent; echo the worktree path
+#   path            echo the worktree path (empty if not set up yet)
+#   read            echo state.json (or {} if absent / not set up)
+#   write           read JSON from stdin, validate, atomically save as state.json
+#   commit "<msg>"  stage all state files + commit in the worktree if anything changed
+set -uo pipefail
+
+BRANCH="${WH_PM_STATE_BRANCH:-pm-triage-state}"
+# Dedicated identity for state commits: clearly attributable, never fails on a missing
+# global git identity (matters for unattended routine runs). Local-only, so harmless.
+AUTHOR_NAME="${WH_PM_STATE_AUTHOR:-pm-triage routine}"
+AUTHOR_EMAIL="${WH_PM_STATE_EMAIL:-pm-triage@local}"
+asbot=(-c "user.name=${AUTHOR_NAME}" -c "user.email=${AUTHOR_EMAIL}")
+
+_main_root() {
+  local common
+  common="$(git rev-parse --git-common-dir 2>/dev/null)" || return 1
+  [[ -n "$common" ]] || return 1
+  common="$(cd "$common" && pwd)" || return 1   # normalise relative ".git" in the main worktree
+  dirname "$common"                              # parent of <main>/.git  ==  <main>
+}
+_wt_path() { local r; r="$(_main_root)" || return 1; printf '%s\n' "$r/.worktrees/${BRANCH}"; }
+
+# True iff $1 is the root of a real, resolvable linked worktree — NOT a stray dir, a dangling
+# gitfile, or main's repo reached by walking UP (`$wt` is nested inside main, so a stray dir or
+# empty `.git` there makes `--is-inside-work-tree` resolve to main). `--show-toplevel` of those
+# resolves to main or errors; only a genuine worktree reports its own root. `-ef` (inode) is
+# robust to any path-spelling difference between $1 and git's normalised toplevel.
+_is_state_wt() {
+  local top
+  top="$(git -C "$1" rev-parse --show-toplevel 2>/dev/null)" || return 1
+  [[ -n "$top" && "$top" -ef "$1" ]]
+}
+
+cmd="${1:-}"; shift || true
+case "$cmd" in
+  ensure)
+    root="$(_main_root)" || { echo "not inside a git repo" >&2; exit 1; }
+    wt="$root/.worktrees/${BRANCH}"
+    # Already a healthy worktree rooted here? Return it. `_is_state_wt` asserts the resolved
+    # toplevel IS $wt, so a dangling gitfile (move/re-clone) and a stray dir or empty `.git`
+    # (which would otherwise resolve UP to the enclosing main worktree, risking add/commit
+    # against MAIN) both fall through to the self-heal / stray-dir guard below.
+    if _is_state_wt "$wt"; then printf '%s\n' "$wt"; exit 0; fi
+    # Self-heal: if the worktree dir was deleted out from under us (manual rm -rf, a fresh
+    # clone that didn't carry worktrees), the branch + a stale registration can survive and
+    # `worktree add` then fails with "missing but already registered" — wedging the daily
+    # routine until a human intervenes. `prune` clears ONLY provably-missing registrations
+    # (healthy worktrees untouched), so we recover automatically.
+    git -C "$root" worktree prune 2>/dev/null || true
+    # A non-worktree directory squatting the target path can't be auto-resolved — fail loud
+    # with an actionable message instead of git's raw "already exists" fatal.
+    if [[ -e "$wt" ]]; then
+      echo "state path '$wt' exists but isn't a valid worktree; move/remove it, then retry" >&2
+      exit 1
+    fi
+    # Create the orphan branch (empty root commit, no parent) via plumbing so NO working
+    # tree is touched. An existing branch (e.g. after a worktree-only loss) is reused, so its
+    # committed state is preserved. Then check it out in its own worktree.
+    if ! git -C "$root" show-ref --verify --quiet "refs/heads/${BRANCH}"; then
+      empty_tree="$(git -C "$root" mktree </dev/null)" || { echo "mktree failed" >&2; exit 1; }
+      root_commit="$(git -C "$root" "${asbot[@]}" commit-tree "$empty_tree" \
+        -m "pm-triage state: init (orphan, local-only)")" || { echo "commit-tree failed" >&2; exit 1; }
+      git -C "$root" branch "${BRANCH}" "$root_commit" || { echo "branch create failed" >&2; exit 1; }
+    fi
+    git -C "$root" worktree add "$wt" "${BRANCH}" >&2 || { echo "worktree add failed" >&2; exit 1; }
+    printf '%s\n' "$wt"
+    ;;
+  path)
+    wt="$(_wt_path)" || exit 1
+    _is_state_wt "$wt" && printf '%s\n' "$wt" || printf '\n'
+    ;;
+  read)
+    wt="$(_wt_path)" || exit 1
+    if [[ -f "$wt/state.json" ]]; then cat "$wt/state.json"; else echo "{}"; fi
+    ;;
+  write)
+    wt="$(_wt_path)" || exit 1
+    _is_state_wt "$wt" || { echo "state worktree missing/invalid; run: state.sh ensure" >&2; exit 1; }
+    tmp="$wt/.state.json.tmp"
+    # `jq .` exits 0 on EMPTY stdin (0-byte file → would wipe state.json) and on a multi-value
+    # stream — both silent corruption. Require exactly one non-empty JSON value before the mv.
+    if jq . >"$tmp" 2>/dev/null && [[ "$(jq -s 'length' "$tmp" 2>/dev/null)" == "1" ]]; then
+      mv "$tmp" "$wt/state.json"
+    else
+      rm -f "$tmp"; echo "stdin must be exactly one non-empty JSON value" >&2; exit 2
+    fi
+    ;;
+  commit)
+    msg="${1:-pm-triage: state update}"
+    wt="$(_wt_path)" || exit 1
+    _is_state_wt "$wt" || { echo "state worktree missing/invalid; run: state.sh ensure" >&2; exit 1; }
+    git -C "$wt" add -A || { echo "git add failed in $wt" >&2; exit 1; }
+    if git -C "$wt" diff --cached --quiet; then
+      echo "nothing to commit"
+    else
+      git -C "$wt" "${asbot[@]}" commit -q -m "$msg" && git -C "$wt" rev-parse --short HEAD
+    fi
+    ;;
+  *) echo "usage: state.sh {ensure|path|read|write|commit \"<msg>\"}" >&2; exit 2 ;;
+esac


### PR DESCRIPTION
## What

Reworks the local-only `/pm-triage` Claude Code skill so it can run as a recurring **local** routine (Claude desktop app, not cloud) via a new `all` scope that does `status` + `backlog` + `todos` in one incremental pass.

- **`safe-auto` is now the default run mode.** It auto-applies low-risk changes (set *missing* board Priority, fix board Status to reality, file clearly-new issues with provenance ≤8/run, tick epic boxes for closed issues). Risky changes (teammate priority changes, security/disclosure, closes/dupes, cross-repo) are surfaced for a human — **asked** when you're watching, **queued** to `pending.md` when unattended. `auto` / `report-only` / `propose` remain as explicit overrides.
- **Routine state lives on a local-only orphan branch `pm-triage-state`** in its own worktree, managed by `scripts/state.sh`. It shares no history with `main`, is **never pushed by default** (private — teammates can't see it), is stable across worktrees (path derived from the shared git common dir), and gives a versioned audit trail. Holds `state.json` (`last_sha` + a `filed` dedupe index), `pending.md`, and `runs.log`.
- **`references/routine.md`** documents the setup: the paste-ready desktop-routine prompt, cadence, and the `.claude/settings.local.json` permission allowlist.

## Why local + orphan branch

Cloud Claude Code can't run this repo's flows (no `gh` auth, no Docker for `make ci`, the `.githooks` / `agent-bash-gate` gates assume the local setup). For state: a GitHub issue as a ledger is leaky (teammates notified / can comment) and heavyweight; a plain gitignored dir forks per-worktree (7 here); `.git/pm-triage/` is opaque. A local-only orphan branch is private, versioned, cross-worktree-stable, and syncable later if wanted (`git push -u origin pm-triage-state`, left off for now).

## Testing & review

- `scripts/state.sh` validated end-to-end: orphan create, `write`/`read`/`commit` round-trip, cross-worktree path stability, and the full self-heal + guard matrix (rm-rf'd worktree → self-heal with state preserved; dangling `.git` file; stray `.git` dir; plain stray dir; empty / multi-value stdin all rejected without wiping state).
- `make verify` + full `make ci` green.
- Pre-push reviewers (`pre-push-reviewer` + `docs-reviewer`) ran to `ship_it`. They caught and I fixed a self-heal wedge, a dangling-gitfile short-circuit, and a stray-`.git`-dir path that could have committed against `main` — every mutating op now fails closed against `main`.

## Scope

Local agent tooling under `.claude/` only — no product code, API, config, or user-facing docs change (the orphan state branch must stay **unpushed**, especially through the public flip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
