### PR TITLE
fix(pm-triage): board.sh bash-3.2 fix + merged-PR reconcile step

### DIFF
--- a/.claude/skills/pm-triage/SKILL.md
+++ b/.claude/skills/pm-triage/SKILL.md
@@ -61,7 +61,8 @@ Turn raw inputs — dogfooding logs, the open-issue backlog, code TODOs, PR/issu
 
 1. `gh pr list --state open` + `gh issue list --state open`; cross-check against the board.
 2. Flag: open PRs with no tracking issue / stale (no update in N days) / out-of-date-with-main; issues with open PRs that should be linked; epic checkboxes whose issues closed (tick them); board items whose Status drifted from reality (closed issue not Done, etc.).
-3. Propose the reconciling edits (comments, board status, checkbox ticks). Don't mass-comment.
+3. **Reconcile MERGED PRs against open tracking issues.** For each PR merged since `last_sha` (`git log --oneline <last_sha>..origin/main`, map commit→PR), check whether it completes a checklist item / precondition in an issue that is **still open** (#149, #268, the epics #194/#228/#294/#326/#327, …) and tick that box (SAFE tier). **Match by content, not `Closes #`:** many PRs — especially `ci:`/`docs:`/`chore:` — finish a tracked deliverable without a closing reference and without closing the issue, so there is *no* closed-issue or reference-graph signal (e.g. #308 provenance → #268's box; #283 runner-migration → #149 L25). Never dismiss the CI/docs/chore commits wholesale — they are often the tracked deliverable. Leave *partial-progress* boxes unticked (a single NO_LCP fix doesn't complete #248's "Lighthouse pass").
+4. Propose the reconciling edits (comments, board status, checkbox ticks). Don't mass-comment.
 
 ## Mode: all (the routine)
 

--- a/.claude/skills/pm-triage/scripts/board.sh
+++ b/.claude/skills/pm-triage/scripts/board.sh
@@ -23,8 +23,24 @@ PNUM="${WH_PROJECT_NUM:-7}"
 PROJ="${WH_PROJECT_ID:-PVT_kwDOCdKSOc4BUEKD}"
 PRIO_FIELD="${WH_PRIORITY_FIELD:-PVTSSF_lADOCdKSOc4BUEKDzhBO0vI}"
 STATUS_FIELD="${WH_STATUS_FIELD:-PVTSSF_lADOCdKSOc4BUEKDzhBO0l8}"
-declare -A PRIO=( [P0]=79628723 [P1]=0a877460 [P2]=da944a9c [P3]=e141a9e0 )
-declare -A STATUS=( [Backlog]=f75ad846 [Ready]=61e4505c [InProgress]=47fc9ee4 [InReview]=df73e18b [Done]=98236657 )
+# Priority/Status option-id maps as `case` lookups, not `declare -A`: associative
+# arrays need bash ≥4, but the routine invokes plain `bash` (= /bin/bash 3.2 on
+# macOS), which would die with "P0: unbound variable". `case` works under 3.2.
+# A bad key returns non-zero so callers can reject it.
+_prio_id() {
+  case "$1" in
+    P0) echo 79628723 ;; P1) echo 0a877460 ;;
+    P2) echo da944a9c ;; P3) echo e141a9e0 ;;
+    *) return 1 ;;
+  esac
+}
+_status_id() {
+  case "$1" in
+    Backlog) echo f75ad846 ;; Ready) echo 61e4505c ;;
+    InProgress) echo 47fc9ee4 ;; InReview) echo df73e18b ;;
+    Done) echo 98236657 ;; *) return 1 ;;
+  esac
+}
 
 _item_id() {
   gh project item-list "$PNUM" --owner "$OWNER" --format json --limit 400 2>/dev/null \
@@ -36,17 +52,18 @@ cmd="${1:-}"; shift || true
 case "$cmd" in
   file)
     prio="$1"; status="$2"; labels="$3"; title="$4"; body="$(cat)"
-    [[ -z "${PRIO[$prio]:-}" || -z "${STATUS[$status]:-}" ]] && { echo "bad priority/status" >&2; exit 2; }
+    prio_id=$(_prio_id "$prio")     || { echo "bad priority: $prio"  >&2; exit 2; }
+    status_id=$(_status_id "$status") || { echo "bad status: $status" >&2; exit 2; }
     url=$(gh issue create --repo "$REPO" --title "$title" --label "$labels" --body "$body") || { echo "create failed" >&2; exit 1; }
     num=$(echo "$url" | grep -oE '[0-9]+$')
     item=""; for _ in 1 2 3 4 5 6; do sleep 3; item=$(_item_id "$num"); [[ -n "$item" ]] && break; done
     [[ -z "$item" ]] && item=$(gh project item-add "$PNUM" --owner "$OWNER" --url "$url" --format json | jq -r '.id')
-    _set "$item" "$PRIO_FIELD" "${PRIO[$prio]}"
-    _set "$item" "$STATUS_FIELD" "${STATUS[$status]}"
+    _set "$item" "$PRIO_FIELD" "$prio_id"
+    _set "$item" "$STATUS_FIELD" "$status_id"
     echo "$num"
     ;;
-  set-priority) item=$(_item_id "$1"); [[ -z "$item" ]] && { echo "#$1 not on board" >&2; exit 1; }; _set "$item" "$PRIO_FIELD" "${PRIO[$2]}"; echo "#$1 -> $2" ;;
-  set-status)   item=$(_item_id "$1"); [[ -z "$item" ]] && { echo "#$1 not on board" >&2; exit 1; }; _set "$item" "$STATUS_FIELD" "${STATUS[$2]}"; echo "#$1 -> $2" ;;
+  set-priority) pid=$(_prio_id "$2")   || { echo "bad priority: $2" >&2; exit 2; }; item=$(_item_id "$1"); [[ -z "$item" ]] && { echo "#$1 not on board" >&2; exit 1; }; _set "$item" "$PRIO_FIELD" "$pid"; echo "#$1 -> $2" ;;
+  set-status)   sid=$(_status_id "$2") || { echo "bad status: $2"   >&2; exit 2; }; item=$(_item_id "$1"); [[ -z "$item" ]] && { echo "#$1 not on board" >&2; exit 1; }; _set "$item" "$STATUS_FIELD" "$sid"; echo "#$1 -> $2" ;;
   item-id)      _item_id "$1" ;;
   open-by-priority)
     tmp=$(mktemp)


### PR DESCRIPTION
Fix-up for the `/pm-triage` skill — two changes.

## 1. `board.sh` runs under bash 3.2 (the actual bug)

`scripts/board.sh` used `declare -A PRIO/STATUS` (associative arrays), which require **bash ≥4**. The routine invokes plain `bash` = `/bin/bash` 3.2 on macOS, so every board write (`file` / `set-priority` / `set-status`) died with `P0: unbound variable` and was being worked around ad-hoc by re-running under `/opt/local/bin/bash`.

Replaced the two maps with `case`-based `_prio_id` / `_status_id` lookup functions, so the script runs **natively under stock /bin/bash 3.2** — no re-exec, no MacPorts/Homebrew dependency, works for teammates too. As a bonus, `set-priority` / `set-status` now validate their value arg (fail-closed, precise message) *before* the network lookup; previously the value was unguarded (would crash under `set -u` on bash 4, or silently send an empty option-id).

- All 9 option IDs preserved byte-for-byte.
- Clean under `/bin/bash` 3.2 **and** bash 5.2; `shellcheck` clean.
- Bad-key paths reject (exit 2) without touching `gh`.

## 2. `SKILL.md` — reconcile merged PRs in the status sweep

Adds an explicit step to the status-sweep mode: reconcile **merged** PRs against still-open tracking issues, matching by content (not `Closes #`), and tick completed checklist boxes (leaving partial-progress boxes alone). Codifies the lesson from the #308→#268 miss.

## Test plan

- `bash -n` + `shellcheck` clean on both bash versions.
- Unit-tested the `case` lookups + bad-key rejection under `/bin/bash` 3.2.
- `make ci` green.

Resolves the "Tooling (blocks board writes under the routine)" item in the pm-triage `pending.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
