### PR TITLE
ci: drop the #312 transition guards and v1 cache fallbacks

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -91,14 +91,10 @@ runs:
         # Same-suffix prefix first (this job's flavor across go.sum bumps),
         # then the bare prefix as a cold-start fallback — it matches any
         # other job's suffixed entry, which still carries the shared module
-        # cache even if its build objects don't apply. The unversioned (v1)
-        # prefixes are transitional warm-start fallbacks; drop them once a
-        # v2 entry has been saved on main.
+        # cache even if its build objects don't apply.
         restore-keys: |
           gobuild-v2-${{ runner.os }}-go${{ inputs.go-cache-suffix }}-
           gobuild-v2-${{ runner.os }}-go-
-          gobuild-${{ runner.os }}-go${{ inputs.go-cache-suffix }}-
-          gobuild-${{ runner.os }}-go-
 
     - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
       if: ${{ inputs.golangci == 'true' }}

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -153,7 +153,7 @@ Queue settings live in the `main branch protection` ruleset's
 
 | Cache | Key | Saved by | Notes |
 |---|---|---|---|
-| Go modules + build | `gobuild-v2-<os>-go<suffix>-<go.sum hash>` | every Go job (own suffix) | Suffix partitions by compile flavor (`-lint`, `-unit`, `-integration`, `-e2e-cov`, `-cov`). v2 = the GOTOOLCHAIN=auto toolchain rides in `~/go/pkg/mod` (no setup-go). **TODO:** drop the unversioned v1 restore-keys fallbacks once a v2 entry exists on main. |
+| Go modules + build | `gobuild-v2-<os>-go<suffix>-<go.sum hash>` | every Go job (own suffix) | Suffix partitions by compile flavor (`-lint`, `-unit`, `-integration`, `-e2e-cov`, `-cov`). v2 = the GOTOOLCHAIN=auto toolchain rides in `~/go/pkg/mod` (no setup-go). |
 | golangci binary + analysis | `golangci-<os>-<Makefile,.golangci.yml hash>` | lint | Analysis cache: ~10s warm vs ~90s. `.bin` also carries shellcheck + actionlint. |
 | pnpm store | `pnpm-<os>-<lockfile hash>` | any node job on miss | Store path resolved from pnpm at runtime. docs-build prunes before its save on a key rotation. |
 | Playwright Chromium | `playwright-<os>-<lockfile hash>` | docs-build | rehype-mermaid renders via headless Chrome at docs build. |
@@ -240,22 +240,3 @@ suite's wall-clock becomes a problem again, start here:
 - Re-run failed jobs is safe everywhere: fragments/dist artifacts
   persist per-run, `download-artifact` finds them instantly, and the
   sticky preview comment updates in place.
-
-## Transition notes (delete when done)
-
-- **v1 gobuild restore-keys** in setup-env: drop after the first main
-  run saves `gobuild-v2-*` entries.
-- **docs-preview comment guard**: the comment step skips with a notice
-  until `scripts/ci/docs-preview-comment.sh` exists on main (it executes
-  from the trusted-main checkout). Remove the guard after merge.
-- **PR-title script guard**: the `PR title` job's step skips with a notice
-  until `scripts/ci/check-pr-title.sh` exists on main (same trusted-main
-  checkout). Title enforcement is advisory via `PR housekeeping` until
-  then. Remove the guard after merge.
-- **Merge-queue ruleset flip**: AFTER the PR adding the `merge_group:`
-  trigger lands on main (ordering matters — flipping first strands every
-  other queued PR with no CI run), update the `main branch protection`
-  ruleset: add the `merge_queue` rule and set
-  `strict_required_status_checks_policy: false` (prepared payload:
-  `gh api -X PUT repos/Wave-RF/WaveHouse/rulesets/15353356 --input
-  tmp/ruleset-merge-queue.json`). Then delete this note.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,16 +113,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
         # Logic lives in scripts/ci/check-pr-title.sh (shellcheck-gated),
         # resolved from this trusted-main checkout like scripts/lint-pr-title.sh.
-        # Transition guard: until this PR merges, main doesn't have the
-        # script yet — skip with a notice (housekeeping.yml's advisory
-        # mirror still reds a bad title, and this PR's own title is valid).
-        # Drop the guard once it's on main. See README "Transition notes".
-        run: |
-          if [ ! -f scripts/ci/check-pr-title.sh ]; then
-            echo "::notice::scripts/ci/check-pr-title.sh is not on the default branch yet — title checked by PR housekeeping during transition."
-            exit 0
-          fi
-          scripts/ci/check-pr-title.sh
+        run: scripts/ci/check-pr-title.sh
 
   # ── Static checks ──────────────────────────────────────────────────
   lint:
@@ -497,10 +488,6 @@ jobs:
       # would skip after the upload step's exit 1 — so a failed deploy is
       # noted rather than leaving a stale "live" comment. Skipped only when
       # no upload was attempted (outcome == 'skipped').
-      #
-      # Transition guard: until this PR merges, main doesn't have the script
-      # yet — skip with a notice instead of failing (the preview URL is still
-      # in the step summary). Drop the guard once it's on main.
       - name: Comment docs preview status
         if: ${{ !cancelled() && (steps.preview.outcome == 'success' || steps.preview.outcome == 'failure') }}
         continue-on-error: true
@@ -510,12 +497,7 @@ jobs:
           URL: ${{ steps.preview.outputs.url }}
           SHA: ${{ github.event.pull_request.head.sha }}
           PREVIEW_OUTCOME: ${{ steps.preview.outcome }}
-        run: |
-          if [ ! -f scripts/ci/docs-preview-comment.sh ]; then
-            echo "::notice::scripts/ci/docs-preview-comment.sh is not on the default branch yet — skipping the sticky comment."
-            exit 0
-          fi
-          scripts/ci/docs-preview-comment.sh
+        run: scripts/ci/docs-preview-comment.sh
 
   # Production: push (or manual dispatch) on main → publish the active
   # version served on wavehouse.dev. Gated on the full pipeline (lint +


### PR DESCRIPTION
## Summary

Post-merge cleanup for #312 — removes the transition scaffolding it carried, now that it's landed on `main`.

- **`ci.yml`** — the `PR title` and docs-preview-comment steps no longer guard on `scripts/ci/{check-pr-title,docs-preview-comment}.sh` existing (the `if [ ! -f … ]; then … exit 0; fi` skip-with-notice). Both scripts are on `main` now, so the steps call them directly. Confirmed present on `origin/main` (the trusted-main checkout these steps use).
- **`.github/actions/setup-env/action.yml`** — drops the two unversioned v1 `gobuild-` restore-key fallbacks, keeping the `gobuild-v2-*` ones. Verified `gobuild-v2-*` caches exist for every suffix (`-lint`/`-unit`/`-integration`/`-e2e-cov`/`-cov`) on `main`, so no cold-cache regression.
- **`.github/workflows/README.md`** — removes the "Transition notes" section and the cache-table v1 TODO.

## The ruleset flip (done out-of-band)

The fourth transition item — the **merge-queue ruleset flip** — was applied directly via the API (it's a branch-protection change, not a code change). The `main branch protection` ruleset now has:
- the `merge_queue` rule (SQUASH, ALLGREEN grouping, `min_entries_to_merge: 1`, up to 5 speculative builds), and
- `strict_required_status_checks_policy: false` (drops the "require branches up to date" requirement — the merge queue's integration re-test replaces it).

So **this PR will itself land through the merge queue** ("Merge when ready").

## Test plan

- [x] `actionlint` + `markdownlint` + `shellcheck` clean (`make lint-gha lint-md lint-sh`)
- [x] `make ci` green locally
- [x] de-guarded scripts confirmed present + executable on `origin/main` (`git cat-file -e origin/main:scripts/ci/check-pr-title.sh`)
- [x] `gobuild-v2-*` caches confirmed present for every suffix on `main` (no cold-cache regression from dropping v1)
- [x] no dangling references to the removed guards / Transition-notes section anywhere in the tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)
