### PR TITLE
fix: `admin_role` added to policy type in typescript sdk

### DIFF
--- a/clients/ts/src/types.ts
+++ b/clients/ts/src/types.ts
@@ -337,6 +337,7 @@ export interface ParamDef {
 
 export interface Policy {
   default_role?: string;
+  admin_role?: string;
   tables: Record<string, TablePolicy>;
 }
 

--- a/docs/src/content/docs/sdk/admin.md
+++ b/docs/src/content/docs/sdk/admin.md
@@ -35,6 +35,7 @@ const { data: policy } = await wh.policy.get();
 // Update policy
 await wh.policy.set({
   default_role: 'viewer',
+  admin_role: 'admin',
   tables: {
     clicks: {
       select: {

--- a/tests/e2e/sdk/admin.test.ts
+++ b/tests/e2e/sdk/admin.test.ts
@@ -68,6 +68,8 @@ describe("Admin", () => {
 
   describe("Policy", () => {
     const testPolicy = {
+      default_role: "viewer",
+      admin_role: "admin",
       tables: {
         [T.clicks]: {
           select: {
@@ -107,6 +109,7 @@ describe("Admin", () => {
       expect(getResult.error).toBeNull();
       expect(getResult.data).toBeDefined();
       expect(getResult.data).toHaveProperty("tables");
+      console.log("Policy get result:", getResult.data);
     });
   });
 

--- a/tests/e2e/sdk/admin.test.ts
+++ b/tests/e2e/sdk/admin.test.ts
@@ -100,6 +100,7 @@ describe("Admin", () => {
       // setting the bare testPolicy would wipe every other suite's tables from
       // the live policy until afterAll restores it.
       const setResult = await wh.policy.set({
+        ...testPolicy,
         tables: { ...(baselinePolicy?.tables ?? {}), ...testPolicy.tables },
       });
       expect(setResult.error).toBeNull();
@@ -109,7 +110,10 @@ describe("Admin", () => {
       expect(getResult.error).toBeNull();
       expect(getResult.data).toBeDefined();
       expect(getResult.data).toHaveProperty("tables");
-      console.log("Policy get result:", getResult.data);
+      expect(getResult.data).toMatchObject({
+        default_role: "viewer",
+        admin_role: "admin",
+      });
     });
   });
 


### PR DESCRIPTION
When we merged in `admin_role` in the set/get policy route, we forgot to add it to the typescript sdk too, so typescript currently highlights an attempt to set it with `Object literal may only specify known properties, and 'admin_role' does not exist in type 'Policy'.`

This PR adds it to the type, adds a small test for it, and updates the SDK docs to mention it.